### PR TITLE
Remove Wiki Invalid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,3 @@ Please make sure to follow our contribution guidelines before submitting a pull 
 ## License
 
 PatchWise is licensed under the BSD-3-clause License. See [LICENSE.txt](LICENSE.txt) for the full license text.
-
-### See Also
-
-- [PatchWise Wiki](https://github.com/your-username/PatchWise/wiki)


### PR DESCRIPTION
@davidgantman you can ignore/close this after the workflow runs. I just wanted to submit a PR to properly trigger the full QCOM Preflight checks now that the repo is public - some checks only run on PR and if the repo is public.
 
 BTW, the wiki URL is invalid 😜 