### PR TITLE
__init: Move sandbox to tempfs

### DIFF
--- a/patchwise/__init__.py
+++ b/patchwise/__init__.py
@@ -8,8 +8,8 @@ PACKAGE_PATH = Path(__file__).resolve().parent
 
 PACKAGE_NAME = __name__.split(".")[0]
 
-# Define the sandbox/workspace path relative to the package location
-SANDBOX_PATH = PACKAGE_PATH / "sandbox"
+# Define the sandbox/workspace path in tmp directory
+SANDBOX_PATH = Path("/tmp") / PACKAGE_NAME / "sandbox"
 SANDBOX_BIN = SANDBOX_PATH / "bin"
 # Define the kernel workspace path
 KERNEL_PATH = SANDBOX_PATH / "kernel"


### PR DESCRIPTION
Move the sandbox directory to tempfs so that disk space is not unnecessarily consumed by PatchWise.

With above change:
09:43:39 I patchwise.patch_review.kernel_tree kernel_tree.py#116: Worktree already exists at /tmp/patchwise/sandbox/kernel

Closes #9 