### PR TITLE
Add support for running checkpatch directly on patch files

### DIFF
--- a/patchwise/main.py
+++ b/patchwise/main.py
@@ -15,6 +15,7 @@ from .patch_review import (
     get_selected_reviews_from_args,
     install_missing_dependencies,
     review_patch,
+    review_patch_files,
 )
 from .patch_review.ai_review.ai_review import add_ai_arguments, apply_ai_args
 from .patch_review.kernel_tree import create_git_worktree
@@ -91,6 +92,11 @@ def main():
 
     if args.install:
         install_missing_dependencies(reviews)
+        return
+
+    if args.patch_files:
+        logger.info(f"Reviewing patch files: {args.patch_files}")
+        review_patch_files(reviews, args.patch_files)
         return
 
     repo = Repo(args.repo_path)

--- a/patchwise/patch_review/decorators.py
+++ b/patchwise/patch_review/decorators.py
@@ -13,6 +13,7 @@ LLM_REVIEWS: List[Type[AiReview]] = []
 STATIC_ANALYSIS_REVIEWS: List[Type[StaticAnalysis]] = []
 SHORT_REVIEWS: List[Type[PatchReview]] = []
 LONG_REVIEWS: List[Type[PatchReview]] = []
+PATCH_FILES_REVIEWS: List[Type[PatchReview]] = []
 
 
 # Decorators for each review type
@@ -46,5 +47,11 @@ def register_short_review(cls: Type[Any]) -> Type[Any]:
 def register_long_review(cls: Type[Any]) -> Type[Any]:
     if cls not in LONG_REVIEWS:
         LONG_REVIEWS.append(cls)
+    register_patch_review(cls)
+    return cls
+
+def register_patch_files_review(cls: Type[Any]) -> Type[Any]:
+    if cls not in PATCH_FILES_REVIEWS:
+        PATCH_FILES_REVIEWS.append(cls)
     register_patch_review(cls)
     return cls

--- a/patchwise/patch_review/static_analysis/checkpatch.py
+++ b/patchwise/patch_review/static_analysis/checkpatch.py
@@ -6,6 +6,7 @@ import os
 from patchwise.patch_review.decorators import (
     register_short_review,
     register_static_analysis_review,
+    register_patch_files_review,
 )
 
 from .static_analysis import StaticAnalysis
@@ -13,6 +14,7 @@ from .static_analysis import StaticAnalysis
 
 @register_static_analysis_review
 @register_short_review
+@register_patch_files_review
 class Checkpatch(StaticAnalysis):
     """
     Perform static analysis on kernel commits using the checkpatch.pl script.
@@ -24,30 +26,44 @@ class Checkpatch(StaticAnalysis):
         pass
 
     def run(self) -> str:
+        checkpatch_cmd = [
+            os.path.join("scripts", "checkpatch.pl"),
+            "--quiet",
+            "--subjective",
+            "--strict",
+            "--showfile",
+            "--show-types",
+            "--codespell",
+            "--mailback",
+            "--ignore",
+            ",".join(
+                [
+                    # We review patches one at a time and don't try to apply to
+                    # tree. So, checkpatch will not see that earlier patch adds
+                    # the DT string
+                    "UNDOCUMENTED_DT_STRING",
+                    "FILE_PATH_CHANGES",
+                    "CONFIG_DESCRIPTION",
+                ]
+            ),
+        ]
+
+        if self.commit and self.base_commit:
+            self.logger.debug("Checkpatch: Running in Git commit mode.")
+            checkpatch_cmd.append("--git")
+            checkpatch_cmd.append(self.base_commit.hexsha + "..." + self.commit.hexsha)
+            current_working_directory = str(self.repo.working_tree_dir) if self.repo else os.getcwd()
+        elif self.patch_files:
+            self.logger.debug("Checkpatch: Running in patch file mode.")
+            checkpatch_cmd.extend(map(str, self.patch_files))
+            current_working_directory = str(self.repo.working_tree_dir) if self.repo else os.getcwd()
+
+        else:
+            self.logger.error("No valid input (commits or patch_files) for Checkpatch review.")
+            return "Error: No input provided for Checkpatch review."
+
         return self.run_cmd_with_timer(
-            [
-                os.path.join("scripts", "checkpatch.pl"),
-                "--quiet",
-                "--subjective",
-                "--strict",
-                "--showfile",
-                "--show-types",
-                "--codespell",
-                "--mailback",
-                "--ignore",
-                ",".join(
-                    [
-                        # We review patches one at a time and don't try to apply to
-                        # tree. So, checkpatch will not see that earlier patch adds
-                        # the DT string
-                        "UNDOCUMENTED_DT_STRING",
-                        "FILE_PATH_CHANGES",
-                        "CONFIG_DESCRIPTION",
-                    ]
-                ),
-                "--git",
-                self.base_commit.hexsha + "..." + self.commit.hexsha,
-            ],
-            cwd=str(self.repo.working_tree_dir),
+            checkpatch_cmd,
+            cwd=current_working_directory,
             desc="checkpatch",
         )


### PR DESCRIPTION
Add support for running checkpatch directly on patch files, for example: 

patchwise --patch-files 0001-sched-Combine-ENQUEUE_MIGRATED-check-in-activate_tas.patch
12:00:23 I patchwise.main main.py#98: Reviewing patch files: [PosixPath('0001-sched-Combine-ENQUEUE_MIGRATED-check-in-activate_tas.patch')]
12:00:24 I patchwise.patch_review __init__.py#86: Checkpatch result:

total: 1 errors, 0 warnings, 0 checks, 12 lines checked