### PR TITLE
Add persistent default configuration YAML file

### DIFF
--- a/patchwise/default_config.yaml
+++ b/patchwise/default_config.yaml
@@ -1,0 +1,1 @@
+log_level: "INFO"

--- a/patchwise/logger_setup.py
+++ b/patchwise/logger_setup.py
@@ -68,11 +68,12 @@ def setup_logger(log_file: str = LOG_PATH, log_level: str = "INFO"):
 
 def add_logging_arguments(
     parser_or_group: argparse.ArgumentParser | argparse._ArgumentGroup,
+    config: dict
 ):
     parser_or_group.add_argument(
         "--log-level",
         choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
-        default="INFO",
+        default=config["log_level"],
         help="Set the logging level. (default: %(default)s)",
     )
     parser_or_group.add_argument(

--- a/patchwise/utils/config.py
+++ b/patchwise/utils/config.py
@@ -1,0 +1,46 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from platformdirs import user_config_dir
+from patchwise import PACKAGE_PATH
+from pathlib import Path
+from typing import Dict, Any, cast
+import yaml
+
+CONFIG_DIR = Path(user_config_dir())
+DEFAULT_CONFIG_PATH = PACKAGE_PATH / "default_config.yaml"
+USER_CONFIG_PATH = CONFIG_DIR / "patchwise_config.yaml"
+
+
+def read_from_config(path: Path) -> Dict[str, Any]:
+    with open(path, "r") as file:
+        config_dict = yaml.safe_load(file)
+
+    if config_dict is None:
+        return {}
+
+    if not isinstance(config_dict, dict):
+        raise ValueError(f"Config must be a dictionary, got {type(config_dict)}")
+
+    return cast(Dict[str, Any], config_dict)
+
+
+def parse_config() -> Dict[str, Any]:
+    """
+    Parses both user and default configuration files and returns the union of the two with user taking precedence.
+    """
+    default_options = read_from_config(DEFAULT_CONFIG_PATH)
+    try:
+        user_options = read_from_config(USER_CONFIG_PATH)
+    except FileNotFoundError:
+        user_options: Dict[str, Any] = {}
+
+    if not user_options:
+        return default_options
+
+    combined_options = {
+        **default_options,
+        **{k: v for k, v in user_options.items() if v is not None},
+    }
+
+    return combined_options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pytest>=8.3.5",
     "rich-argparse>=1.7.0",
     "tqdm>=4.67.1",
+    "platformdirs>=4.3.8"
 ]
 
 [project.scripts]
@@ -30,4 +31,4 @@ where = ["."]
 include = ["patchwise*"]
 
 [tool.setuptools.package-data]
-patchwise = ["patches/**"]
+patchwise = ["patches/**", "default_config.yaml"]


### PR DESCRIPTION
Adds initial config structure. User will create their individual config file using "nano ~/.config/patchwise_config.yaml" or whichever text editor they would prefer. Resolves #42 and #43. 