### PR TITLE
Add API key disclaimer in default config

### DIFF
--- a/patchwise/default_config.yaml
+++ b/patchwise/default_config.yaml
@@ -1,1 +1,5 @@
 log_level: "INFO"
+api_key_disclaimer:
+    message: "PatchWise uses LiteLLM to interact with your preferred model provider (default: OpenAI). LiteLLM will automatically retrieve the API key from your environment variables if it is set based on the API URL provided to LiteLLM (default: OpenAI). Please confirm that you acknowledge that your API key may be used, if set in your environment. Select 'Yes' to proceed, 'No' to abort, and 'Yes. Don't show again' to proceed and disable this prompt."
+    options: ["Yes", "No", "Yes. Don't show again"]
+    no_reprompt: false


### PR DESCRIPTION
Closes #44. Works with previously written logic in PR #45.