### PR TITLE
Add LLM Learn Reviewer - AI-Powered Code Review with Historical Learning

### DIFF
--- a/patchwise/main.py
+++ b/patchwise/main.py
@@ -16,6 +16,10 @@ from .patch_review import (
     review_commit,
 )
 from .patch_review.ai_review.ai_review import add_ai_arguments, apply_ai_args
+from .patch_review.ai_review.llm_learn_reviewer import (
+    add_llmlearn_arguments,
+    apply_llmlearn_args,
+)
 from .utils.config import parse_config, update_user_config
 from .utils.tui import display_prompt_with_options
 
@@ -43,6 +47,9 @@ def parse_args(config: dict) -> argparse.Namespace:
 
     ai_group = parser.add_argument_group("AI Review Options")
     add_ai_arguments(ai_group)
+
+    llmlearn_group = parser.add_argument_group("LLMLearnReviewer Options")
+    add_llmlearn_arguments(llmlearn_group)
 
     logging_group = parser.add_argument_group("Logging Options")
     add_logging_arguments(logging_group, config)
@@ -93,6 +100,7 @@ def main():
     setup_logger(log_file=args.log_file, log_level=args.log_level)
 
     apply_ai_args(args)
+    apply_llmlearn_args(args)
 
     reviews = get_selected_reviews_from_args(args)
 

--- a/patchwise/main.py
+++ b/patchwise/main.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+import sys
 from pathlib import Path
 
 from git import Repo
@@ -100,9 +101,22 @@ def main():
     setup_logger(log_file=args.log_file, log_level=args.log_level)
 
     apply_ai_args(args)
-    apply_llmlearn_args(args)
 
     reviews = get_selected_reviews_from_args(args)
+
+    if "LLMLearnReviewer" not in reviews and (
+        args.url is not None or args.cache_dir is not None
+    ):
+        passed = [
+            flag
+            for flag, val in (("--url", args.url), ("--cache_dir", args.cache_dir))
+            if val is not None
+        ]
+        sys.exit(
+            f"error: {' and '.join(passed)} only effective with --reviews llmlearnreviewer"
+        )
+
+    apply_llmlearn_args(args)
 
     repo = Repo(args.repo_path)
     commits = get_commits(repo, args.commits)

--- a/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
+++ b/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
@@ -1,4 +1,6 @@
-import requests
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
 import xml.etree.ElementTree as ET
 import email
 from email.policy import default

--- a/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
+++ b/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
@@ -1,0 +1,388 @@
+import requests
+import xml.etree.ElementTree as ET
+import email
+from email.policy import default
+import time
+import re
+from datetime import datetime
+from abc import ABC, abstractmethod
+import numpy as np
+from qgenie import QGenieClient
+from typing import Any, Dict
+import sys
+import os
+import json
+from pathlib import Path
+from patchwise import KERNEL_PATH, SANDBOX_PATH
+
+class LoreCrawler:
+    def __init__(self, config: Dict[str, Any], logger):
+        self.config = config
+        self.logger = logger
+        self.session = requests.Session()
+        self.session.headers.update({'User-Agent': 'FetchReviewerComment/1.0'})
+        self.max_context_lines = config.get("MAX_CONTEXT_LINES", 40)
+        if config.get("PROXY"):
+            self.session.proxies = {"http": config["PROXY"], "https": config["PROXY"]}
+
+    def _is_email_header(self, line):
+        import re
+        patterns = [
+            r'^On\s+.+\s+wrote:$',                    # On ... wrote:
+            r'^On\s+\d{2}/\d{2}/\d{4}\s+\d{2}:\d{2}', # On 09/01/2026 10:43
+            r'^On\s+\w{3},\s+\d{1,2}\s+\w{3}\s+\d{4}', # On Tue, 14 Jan 2025
+            r'^On\s+\w{3},\s+\w{3}\s+\d{1,2},\s+\d{4}', # On Tue, Jan 14, 2025
+        ]
+
+        for pattern in patterns:
+            if re.match(pattern, line, re.IGNORECASE):
+                return True
+        return False
+
+    def _parse_email_segments(self, body):
+        if not body:
+            return []
+        lines = body.splitlines()
+        segments = []
+        context_buffer = []
+        current_comment = []
+
+        for line in lines:
+            stripped = line.strip()
+
+            if stripped.startswith(">"):
+                if current_comment:
+                    context_lines = context_buffer[-self.max_context_lines:] if len(context_buffer) > self.max_context_lines else context_buffer
+                    context_lines = [line for line in context_lines if line.strip()]
+                    context = "\n".join(context_lines).strip()
+
+                    comment_lines = [line for line in current_comment if line.strip()]
+                    comment = "\n".join(current_comment).strip()
+
+                    if context and comment:
+                        if(self._has_code_context(context)):
+                            file_path = self._extract_file_path(context)
+                        else:
+                            file_path = None
+                        segments.append((context, comment, file_path))
+                    current_comment = []
+
+                content = stripped.lstrip(">").strip()
+                if content.startswith("diff --git"):
+                    context_buffer = []
+                if content:
+                    context_buffer.append(content)
+
+            elif stripped:
+                if self._is_email_header(stripped):
+                    continue
+
+                if stripped in ["--", "---", "Best regards,", "Thanks,", "Cheers,"]:
+                    continue
+
+                current_comment.append(stripped)
+
+        if current_comment:
+            context_lines = context_buffer[-self.max_context_lines:] if len(context_buffer) > self.max_context_lines else context_buffer
+            context_lines = [line for line in context_lines if line.strip()]
+            context = "\n".join(context_lines).strip()
+
+            comment_lines = [line for line in current_comment if line.strip()]
+            comment = "\n".join(current_comment).strip()
+
+            if context and comment:
+                if (self._has_code_context(context)):
+                   file_path = self._extract_file_path(context)
+                else:
+                   file_path = None
+                segments.append((context, comment, file_path))
+
+        return segments
+
+    def _extract_file_path(self, context):
+        import re
+
+        lines = context.split('\n')
+
+        for line in lines:
+            if line.startswith('diff --git'):
+                match = re.search(r'b/([^\s]+)', line)
+                if match:
+                    return match.group(1)
+
+            if line.startswith('+++') or line.startswith('---'):
+                match = re.search(r'[ab]/([^\s]+)', line)
+                if match:
+                    return match.group(1)
+
+        return None
+
+    def _has_code_snippet(self, comment):
+        import re
+
+        code_patterns = [
+            r'\bif\s*\(',              # if (...)
+            r'\belse\s+if\s*\(',       # else if (...)
+            r'\bwhile\s*\(',           # while (...)
+            r'\bfor\s*\(',             # for (...)
+            r'\bswitch\s*\(',          # switch (...)
+            r'\breturn\s+\w+',         # return something (not just return)
+            r'\w+\s*\([^)]*\)',        # function_call(...) must have matching parentheses
+            r'\w+\s*\[\w*\]',          # array[index] must have matching square brackets
+            r'\w+\s*->\s*\w+',         # pointer->member (both sides of the arrow must be identifiers)
+            r'[{};]\s*$',              # code block symbols (at the end of the line)
+            r'==|!=|<=|>=|&&|\|\|',    # comparison / logical operators
+            r'\bstruct\s+\w+',         # struct name
+            r'\b0x[0-9a-fA-F]+',       # hexadecimal numbers
+            r'#define\b',              # macro definitions
+            r'#include\b',             # header file includes
+        ]
+
+        for pattern in code_patterns:
+            if re.search(pattern, comment):
+                return True
+
+        return False
+
+    def _has_code_context(self, context):
+        if not context:
+            return False
+
+        code_indicators = [
+            'diff --git',               # git diff
+            '+++',                      # patch file
+            '---',                      # patch file
+            '@@',                       # hunk
+            '#include',                 # C/C++ include
+            'static ',                  # function definitions
+            'struct ',                  # struct definitions
+            'void ',                    # function definitions
+            'int ',                     # variable definitions
+            'return ',                  # return
+            '{',                        # code blocks
+            '}',                        # code blocks
+             r'\bif\s*\(',              # if (...)
+             r'\belse\s+if\s*\(',       # else if (...)
+             r'\bwhile\s*\(',           # while (...)
+             r'\bfor\s*\(',             # for (...)
+             r'\bswitch\s*\(',          # switch (...)
+             r'\breturn\s+',            # return ...
+             r'\w+\s*\(',               # function_call(...)
+             r'\w+\s*\[',               # array[...]
+             r'\w+\s*->',               # pointer->member
+             r'[{};]',                  # block delimiters (or block symbols)
+             r'==|!=|<=|>=|&&|\|\|',    # comparison / logical operators
+             r'\bstruct\s+\w+',         # struct name
+             r'\b0x[0-9a-fA-F]+',       # hexadecimal literals
+        ]
+
+        context_lower = context.lower()
+
+        for indicator in code_indicators:
+            if indicator.lower() in context_lower:
+                return True
+
+        lines = context.split('\n')
+        indented_lines = sum(1 for line in lines if line.startswith('    ') or line.startswith('\t'))
+
+        if len(lines) > 0 and indented_lines / len(lines) > 0.3:
+            return True
+
+        return False
+
+    def _fetch_raw_body(self, link):
+        raw_link = link.rstrip('/') + "/raw"
+        try:
+            r = self.session.get(raw_link, timeout=10)
+            r.raise_for_status()
+            msg = email.message_from_bytes(r.content, policy=default)
+            body = ""
+            if msg.is_multipart():
+                for part in msg.walk():
+                    if part.get_content_type() == "text/plain":
+                        payload = part.get_payload(decode=True)
+                        if payload: body += payload.decode('utf-8', errors='replace')
+            else:
+                payload = msg.get_payload(decode=True)
+                if payload: body = payload.decode('utf-8', errors='replace')
+            return body
+        except Exception:
+            return None
+
+    def _is_valid_comment(self, text):
+        if not text: return False
+
+        lines = [line.strip() for line in text.splitlines()
+            if not line.strip().startswith(">") and line.strip()]
+        clean_text = " ".join(lines).lower()
+
+        if not clean_text: return False
+
+        if clean_text.strip().lower() in ["suzuki"]:
+            return False
+
+        status_keywords = ["applied"]
+        if any(keyword in clean_text for keyword in status_keywords):
+            return False
+        if len(clean_text) < self.config["NOISE_LENGTH"]:
+            for keyword in self.config["NOISE_KEYWORDS"]:
+                    if (keyword in clean_text) and ("but" not in clean_text) and (self._has_code_snippet(clean_text) is False):
+                        return False
+
+        return True
+
+    def _fetch_all_entries(self, query):
+        all_entries = []
+        offset = 0
+        page = 1
+        ns = {'atom': 'http://www.w3.org/2005/Atom'}
+
+        while True:
+            self.logger.debug(f"[*] Crawler: fetching page {page} (offset={offset})...")
+
+            try:
+                params = {
+                    'q': query,
+                    'x': 'A',
+                    'o': offset
+                }
+
+                res = self.session.get("https://lore.kernel.org/all/",
+                                        params=params,
+                                        timeout=15)
+                res.raise_for_status()
+
+                root = ET.fromstring(res.content)
+                entries = root.findall('atom:entry', ns)
+
+                if not entries:
+                    self.logger.debug(f"[*] Crawler: Page {page} no result, page end")
+                    break
+
+                all_entries.extend(entries)
+                self.logger.debug(f"[*] Crawler: Page {page} has {len(entries)} comments")
+
+                if len(entries) < 200:
+                    self.logger.debug(f"[*] Crawler: Fetched all results")
+                    break
+
+                offset += len(entries)
+                page += 1
+                time.sleep(1)
+            except Exception as e:
+                self.logger.debug(f"[!] Crawler: Facing issue while fetching page {page}: {e}")
+                break
+        return all_entries
+
+    def run(self):
+        query = f'f:"{self.config["MAINTAINER"]}"'
+        self.logger.debug(f"[*] Crawler: searching {query}...")
+        documents = []
+        limit = self.config.get("LIMIT_PER_REVIEWER", 0)
+
+        try:
+            offset = 0
+            page = 1
+            total_entries_processed = 0
+            ns = {'atom': 'http://www.w3.org/2005/Atom'}
+
+            while True:
+                if limit > 0 and len(documents) >= limit:
+                    self.logger.debug(f"[*] Crawler: The valid comment limit ({limit}) has been reached. Stopping crawling.")
+                    break;
+
+                self.logger.debug(f"[*] Crawler: Fetching page {page} (offset={offset})...")
+
+                try:
+                    params = {
+                        'q': query,
+                        'x': 'A',
+                        'o': offset
+                    }
+
+                    res = self.session.get("https://lore.kernel.org/all/",
+                                            params=params,
+                                            timeout=15)
+                    res.raise_for_status()
+
+                    root = ET.fromstring(res.content)
+                    entries = root.findall('atom:entry', ns)
+
+                    if not entries:
+                        self.logger.debug(f"[*] Crawler: No results on page {page}; stopping crawl.")
+                        break
+
+                    self.logger.debug(f"[*] Crawler: Page {page} returned {len(entries)} entries. Beginning processing...")
+
+                    for i,entry in enumerate(entries):
+                        if limit > 0 and len(documents) >= limit:
+                            self.logger.debug(f"*] Crawler: The valid comment limit ({limit}) has been reached. Stopping processing.")
+                            break;
+
+                        total_entries_processed += 1
+                        link = entry.find('atom:link', ns).attrib['href']
+                        title = entry.find('atom:title', ns).text
+                        date = entry.find('atom:updated', ns).text
+                        body = self._fetch_raw_body(link)
+
+                        if body:
+                            segments = self._parse_email_segments(body)
+                            valid_count = 0
+                            for seg_idx, (context, comment, file_path) in enumerate(segments):
+                                if limit > 0 and len(documents) >= limit:
+                                    break
+                                if comment and context and self._is_valid_comment(comment):
+                                    doc = {
+                                        "content": context,
+                                        "comment": comment,
+                                        "title": title,
+                                        "file_path": file_path,
+                                        "link": link,
+                                    }
+
+                                    documents.append(doc)
+                                    valid_count += 1
+
+                            if valid_count > 0:
+                                self.logger.debug(f"[{total_entries_processed}] Kept as valid ({valid_count} comment segments) - Current total: {len(documents)}")
+                                self.logger.debug(f"Title: {title}")
+                                self.logger.debug(f"Link: {link}")
+
+                            else:
+                                self.logger.debug(f"[{total_entries_processed}] - Filtered out")
+                                self.logger.debug(f"Title: {title}")
+                                self.logger.debug(f"Link: {link}")
+                        time.sleep(0.5)
+
+                    if limit > 0 and len(documents) >= limit:
+                        break
+
+                    if len(entries) < 200:
+                        self.logger.debug(f"[*] Crawler: All available data has been processed")
+                        break
+
+                    offset += len(entries)
+                    page += 1
+                    time.sleep(1)
+
+                except Exception as e:
+                    self.logger.debug(f"[!] Crawler: Error occurred while fetching page {page}: {e}")
+                    break
+        except Exception as e:
+            self.logger.error(f"[!] Crawler Error: {e}")
+
+        self.logger.debug(f"[*] Crawler: Task completed. Processed a total of {total_entries_processed} raw records and generated {len(documents)} valid comment documents.")
+
+        if documents:
+            import json
+            from datetime import datetime
+
+            maintainer_name = self.config["MAINTAINER"].replace(" ", "_").replace("@", "_at_")
+            json_filename = os.path.join(SANDBOX_PATH, f"crawled_{maintainer_name}.json")
+            os.makedirs(SANDBOX_PATH, exist_ok=True)
+
+            with open(json_filename, 'w', encoding='utf-8') as f:
+                json.dump(documents, f, ensure_ascii=False, indent=2)
+            self.logger.debug(f"[*] Saved JSON file: {json_filename}")
+
+        return documents

--- a/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
+++ b/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
@@ -1,39 +1,82 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import xml.etree.ElementTree as ET
 import email
-from email.policy import default
-import time
-import re
-from datetime import datetime
-from abc import ABC, abstractmethod
-import numpy as np
-from qgenie import QGenieClient
-from typing import Any, Dict
-import sys
-import os
 import json
-from pathlib import Path
-from patchwise import KERNEL_PATH, SANDBOX_PATH
+import os
+import re
+import time
+import xml.etree.ElementTree as ET
+from email.policy import default
+from typing import Any, Dict
+
+import requests
+
+from patchwise import SANDBOX_PATH
+
+DEFAULT_SOURCE_URL = "https://lore.kernel.org/all/"
+
+# Regex patterns that indicate C/kernel-style code. Shared by both
+# _has_code_snippet (matches inside a comment body) and _has_code_context
+# (matches inside a quoted diff/context block).
+_CODE_REGEX_PATTERNS = (
+    r"\bif\s*\(",
+    r"\belse\s+if\s*\(",
+    r"\bwhile\s*\(",
+    r"\bfor\s*\(",
+    r"\bswitch\s*\(",
+    r"\breturn\s+\w+",
+    r"\w+\s*\([^)]*\)",
+    r"\w+\s*\[\w*\]",
+    r"\w+\s*->\s*\w+",
+    r"[{};]\s*$",
+    r"==|!=|<=|>=|&&|\|\|",
+    r"\bstruct\s+\w+",
+    r"\b0x[0-9a-fA-F]+",
+    r"#define\b",
+    r"#include\b",
+)
+
+# Plain substrings characteristic of a quoted diff/context block.
+_DIFF_CONTEXT_SUBSTRINGS = (
+    "diff --git",
+    "+++",
+    "---",
+    "@@",
+    "static ",
+    "void ",
+    "int ",
+)
+
+
+def _matches_code_pattern(text: str) -> bool:
+    return any(re.search(p, text) for p in _CODE_REGEX_PATTERNS)
+
 
 class LoreCrawler:
     def __init__(self, config: Dict[str, Any], logger):
         self.config = config
         self.logger = logger
         self.session = requests.Session()
-        self.session.headers.update({'User-Agent': 'FetchReviewerComment/1.0'})
+        self.session.headers.update({"User-Agent": "FetchReviewerComment/1.0"})
         self.max_context_lines = config.get("MAX_CONTEXT_LINES", 40)
+        self.source_url = config.get(
+            "SOURCE_URL",
+            os.environ.get("PATCHWISE_LORE_URL", DEFAULT_SOURCE_URL),
+        )
+        self.cache_dir = config.get(
+            "CACHE_DIR",
+            os.environ.get("PATCHWISE_CACHE_DIR", str(SANDBOX_PATH)),
+        )
         if config.get("PROXY"):
             self.session.proxies = {"http": config["PROXY"], "https": config["PROXY"]}
 
     def _is_email_header(self, line):
-        import re
         patterns = [
-            r'^On\s+.+\s+wrote:$',                    # On ... wrote:
-            r'^On\s+\d{2}/\d{2}/\d{4}\s+\d{2}:\d{2}', # On 09/01/2026 10:43
-            r'^On\s+\w{3},\s+\d{1,2}\s+\w{3}\s+\d{4}', # On Tue, 14 Jan 2025
-            r'^On\s+\w{3},\s+\w{3}\s+\d{1,2},\s+\d{4}', # On Tue, Jan 14, 2025
+            r"^On\s+.+\s+wrote:$",
+            r"^On\s+\d{2}/\d{2}/\d{4}\s+\d{2}:\d{2}",
+            r"^On\s+\w{3},\s+\d{1,2}\s+\w{3}\s+\d{4}",
+            r"^On\s+\w{3},\s+\w{3}\s+\d{1,2},\s+\d{4}",
         ]
 
         for pattern in patterns:
@@ -62,7 +105,7 @@ class LoreCrawler:
                     comment = "\n".join(current_comment).strip()
 
                     if context and comment:
-                        if(self._has_code_context(context)):
+                        if self._has_code_context(context):
                             file_path = self._extract_file_path(context)
                         else:
                             file_path = None
@@ -93,107 +136,55 @@ class LoreCrawler:
             comment = "\n".join(current_comment).strip()
 
             if context and comment:
-                if (self._has_code_context(context)):
-                   file_path = self._extract_file_path(context)
+                if self._has_code_context(context):
+                    file_path = self._extract_file_path(context)
                 else:
-                   file_path = None
+                    file_path = None
                 segments.append((context, comment, file_path))
 
         return segments
 
     def _extract_file_path(self, context):
-        import re
-
-        lines = context.split('\n')
+        lines = context.split("\n")
 
         for line in lines:
-            if line.startswith('diff --git'):
-                match = re.search(r'b/([^\s]+)', line)
+            if line.startswith("diff --git"):
+                match = re.search(r"b/([^\s]+)", line)
                 if match:
                     return match.group(1)
 
-            if line.startswith('+++') or line.startswith('---'):
-                match = re.search(r'[ab]/([^\s]+)', line)
+            if line.startswith("+++") or line.startswith("---"):
+                match = re.search(r"[ab]/([^\s]+)", line)
                 if match:
                     return match.group(1)
 
         return None
 
     def _has_code_snippet(self, comment):
-        import re
-
-        code_patterns = [
-            r'\bif\s*\(',              # if (...)
-            r'\belse\s+if\s*\(',       # else if (...)
-            r'\bwhile\s*\(',           # while (...)
-            r'\bfor\s*\(',             # for (...)
-            r'\bswitch\s*\(',          # switch (...)
-            r'\breturn\s+\w+',         # return something (not just return)
-            r'\w+\s*\([^)]*\)',        # function_call(...) must have matching parentheses
-            r'\w+\s*\[\w*\]',          # array[index] must have matching square brackets
-            r'\w+\s*->\s*\w+',         # pointer->member (both sides of the arrow must be identifiers)
-            r'[{};]\s*$',              # code block symbols (at the end of the line)
-            r'==|!=|<=|>=|&&|\|\|',    # comparison / logical operators
-            r'\bstruct\s+\w+',         # struct name
-            r'\b0x[0-9a-fA-F]+',       # hexadecimal numbers
-            r'#define\b',              # macro definitions
-            r'#include\b',             # header file includes
-        ]
-
-        for pattern in code_patterns:
-            if re.search(pattern, comment):
-                return True
-
-        return False
+        return _matches_code_pattern(comment)
 
     def _has_code_context(self, context):
         if not context:
             return False
 
-        code_indicators = [
-            'diff --git',               # git diff
-            '+++',                      # patch file
-            '---',                      # patch file
-            '@@',                       # hunk
-            '#include',                 # C/C++ include
-            'static ',                  # function definitions
-            'struct ',                  # struct definitions
-            'void ',                    # function definitions
-            'int ',                     # variable definitions
-            'return ',                  # return
-            '{',                        # code blocks
-            '}',                        # code blocks
-             r'\bif\s*\(',              # if (...)
-             r'\belse\s+if\s*\(',       # else if (...)
-             r'\bwhile\s*\(',           # while (...)
-             r'\bfor\s*\(',             # for (...)
-             r'\bswitch\s*\(',          # switch (...)
-             r'\breturn\s+',            # return ...
-             r'\w+\s*\(',               # function_call(...)
-             r'\w+\s*\[',               # array[...]
-             r'\w+\s*->',               # pointer->member
-             r'[{};]',                  # block delimiters (or block symbols)
-             r'==|!=|<=|>=|&&|\|\|',    # comparison / logical operators
-             r'\bstruct\s+\w+',         # struct name
-             r'\b0x[0-9a-fA-F]+',       # hexadecimal literals
-        ]
-
         context_lower = context.lower()
+        if any(sub in context_lower for sub in _DIFF_CONTEXT_SUBSTRINGS):
+            return True
+        if "#include" in context_lower:
+            return True
 
-        for indicator in code_indicators:
-            if indicator.lower() in context_lower:
-                return True
+        if _matches_code_pattern(context):
+            return True
 
-        lines = context.split('\n')
-        indented_lines = sum(1 for line in lines if line.startswith('    ') or line.startswith('\t'))
-
-        if len(lines) > 0 and indented_lines / len(lines) > 0.3:
+        lines = context.split("\n")
+        indented_lines = sum(1 for line in lines if line.startswith("    ") or line.startswith("\t"))
+        if lines and indented_lines / len(lines) > 0.3:
             return True
 
         return False
 
     def _fetch_raw_body(self, link):
-        raw_link = link.rstrip('/') + "/raw"
+        raw_link = link.rstrip("/") + "/raw"
         try:
             r = self.session.get(raw_link, timeout=10)
             r.raise_for_status()
@@ -203,22 +194,29 @@ class LoreCrawler:
                 for part in msg.walk():
                     if part.get_content_type() == "text/plain":
                         payload = part.get_payload(decode=True)
-                        if payload: body += payload.decode('utf-8', errors='replace')
+                        if payload:
+                            body += payload.decode("utf-8", errors="replace")
             else:
                 payload = msg.get_payload(decode=True)
-                if payload: body = payload.decode('utf-8', errors='replace')
+                if payload:
+                    body = payload.decode("utf-8", errors="replace")
             return body
         except Exception:
             return None
 
     def _is_valid_comment(self, text):
-        if not text: return False
+        if not text:
+            return False
 
-        lines = [line.strip() for line in text.splitlines()
-            if not line.strip().startswith(">") and line.strip()]
+        lines = [
+            line.strip()
+            for line in text.splitlines()
+            if not line.strip().startswith(">") and line.strip()
+        ]
         clean_text = " ".join(lines).lower()
 
-        if not clean_text: return False
+        if not clean_text:
+            return False
 
         if clean_text.strip().lower() in ["suzuki"]:
             return False
@@ -228,8 +226,8 @@ class LoreCrawler:
             return False
         if len(clean_text) < self.config["NOISE_LENGTH"]:
             for keyword in self.config["NOISE_KEYWORDS"]:
-                    if (keyword in clean_text) and ("but" not in clean_text) and (self._has_code_snippet(clean_text) is False):
-                        return False
+                if (keyword in clean_text) and ("but" not in clean_text) and (self._has_code_snippet(clean_text) is False):
+                    return False
 
         return True
 
@@ -237,25 +235,19 @@ class LoreCrawler:
         all_entries = []
         offset = 0
         page = 1
-        ns = {'atom': 'http://www.w3.org/2005/Atom'}
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
 
         while True:
             self.logger.debug(f"[*] Crawler: fetching page {page} (offset={offset})...")
 
             try:
-                params = {
-                    'q': query,
-                    'x': 'A',
-                    'o': offset
-                }
+                params = {"q": query, "x": "A", "o": offset}
 
-                res = self.session.get("https://lore.kernel.org/all/",
-                                        params=params,
-                                        timeout=15)
+                res = self.session.get(self.source_url, params=params, timeout=15)
                 res.raise_for_status()
 
                 root = ET.fromstring(res.content)
-                entries = root.findall('atom:entry', ns)
+                entries = root.findall("atom:entry", ns)
 
                 if not entries:
                     self.logger.debug(f"[*] Crawler: Page {page} no result, page end")
@@ -265,7 +257,7 @@ class LoreCrawler:
                 self.logger.debug(f"[*] Crawler: Page {page} has {len(entries)} comments")
 
                 if len(entries) < 200:
-                    self.logger.debug(f"[*] Crawler: Fetched all results")
+                    self.logger.debug("[*] Crawler: Fetched all results")
                     break
 
                 offset += len(entries)
@@ -278,7 +270,7 @@ class LoreCrawler:
 
     def run(self):
         query = f'f:"{self.config["MAINTAINER"]}"'
-        self.logger.debug(f"[*] Crawler: searching {query}...")
+        self.logger.debug(f"[*] Crawler: searching {query} on {self.source_url}...")
         documents = []
         limit = self.config.get("LIMIT_PER_REVIEWER", 0)
 
@@ -286,29 +278,23 @@ class LoreCrawler:
             offset = 0
             page = 1
             total_entries_processed = 0
-            ns = {'atom': 'http://www.w3.org/2005/Atom'}
+            ns = {"atom": "http://www.w3.org/2005/Atom"}
 
             while True:
                 if limit > 0 and len(documents) >= limit:
                     self.logger.debug(f"[*] Crawler: The valid comment limit ({limit}) has been reached. Stopping crawling.")
-                    break;
+                    break
 
                 self.logger.debug(f"[*] Crawler: Fetching page {page} (offset={offset})...")
 
                 try:
-                    params = {
-                        'q': query,
-                        'x': 'A',
-                        'o': offset
-                    }
+                    params = {"q": query, "x": "A", "o": offset}
 
-                    res = self.session.get("https://lore.kernel.org/all/",
-                                            params=params,
-                                            timeout=15)
+                    res = self.session.get(self.source_url, params=params, timeout=15)
                     res.raise_for_status()
 
                     root = ET.fromstring(res.content)
-                    entries = root.findall('atom:entry', ns)
+                    entries = root.findall("atom:entry", ns)
 
                     if not entries:
                         self.logger.debug(f"[*] Crawler: No results on page {page}; stopping crawl.")
@@ -316,15 +302,14 @@ class LoreCrawler:
 
                     self.logger.debug(f"[*] Crawler: Page {page} returned {len(entries)} entries. Beginning processing...")
 
-                    for i,entry in enumerate(entries):
+                    for i, entry in enumerate(entries):
                         if limit > 0 and len(documents) >= limit:
                             self.logger.debug(f"*] Crawler: The valid comment limit ({limit}) has been reached. Stopping processing.")
-                            break;
+                            break
 
                         total_entries_processed += 1
-                        link = entry.find('atom:link', ns).attrib['href']
-                        title = entry.find('atom:title', ns).text
-                        date = entry.find('atom:updated', ns).text
+                        link = entry.find("atom:link", ns).attrib["href"]
+                        title = entry.find("atom:title", ns).text
                         body = self._fetch_raw_body(link)
 
                         if body:
@@ -360,7 +345,7 @@ class LoreCrawler:
                         break
 
                     if len(entries) < 200:
-                        self.logger.debug(f"[*] Crawler: All available data has been processed")
+                        self.logger.debug("[*] Crawler: All available data has been processed")
                         break
 
                     offset += len(entries)
@@ -376,14 +361,11 @@ class LoreCrawler:
         self.logger.debug(f"[*] Crawler: Task completed. Processed a total of {total_entries_processed} raw records and generated {len(documents)} valid comment documents.")
 
         if documents:
-            import json
-            from datetime import datetime
-
             maintainer_name = self.config["MAINTAINER"].replace(" ", "_").replace("@", "_at_")
-            json_filename = os.path.join(SANDBOX_PATH, f"crawled_{maintainer_name}.json")
-            os.makedirs(SANDBOX_PATH, exist_ok=True)
+            os.makedirs(self.cache_dir, exist_ok=True)
+            json_filename = os.path.join(self.cache_dir, f"crawled_{maintainer_name}.json")
 
-            with open(json_filename, 'w', encoding='utf-8') as f:
+            with open(json_filename, "w", encoding="utf-8") as f:
                 json.dump(documents, f, ensure_ascii=False, indent=2)
             self.logger.debug(f"[*] Saved JSON file: {json_filename}")
 

--- a/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
+++ b/patchwise/patch_review/ai_review/fetch_reviewer_comment.py
@@ -60,14 +60,8 @@ class LoreCrawler:
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": "FetchReviewerComment/1.0"})
         self.max_context_lines = config.get("MAX_CONTEXT_LINES", 40)
-        self.source_url = config.get(
-            "SOURCE_URL",
-            os.environ.get("PATCHWISE_LORE_URL", DEFAULT_SOURCE_URL),
-        )
-        self.cache_dir = config.get(
-            "CACHE_DIR",
-            os.environ.get("PATCHWISE_CACHE_DIR", str(SANDBOX_PATH)),
-        )
+        self.source_url = config.get("SOURCE_URL", DEFAULT_SOURCE_URL)
+        self.cache_dir = config.get("CACHE_DIR", str(SANDBOX_PATH))
         if config.get("PROXY"):
             self.session.proxies = {"http": config["PROXY"], "https": config["PROXY"]}
 

--- a/patchwise/patch_review/ai_review/llm_learn_reviewer.py
+++ b/patchwise/patch_review/ai_review/llm_learn_reviewer.py
@@ -10,11 +10,11 @@ from pathlib import Path
 from git.objects.commit import Commit
 
 from patchwise import SANDBOX_PATH
-from patchwise.patch_review.decorators import register_llm_review
+from patchwise.patch_review.decorators import register_patch_review
 from .ai_review import AiReview
 from .fetch_reviewer_comment import LoreCrawler
 
-@register_llm_review
+@register_patch_review
 class LLMLearnReviewer(AiReview):
 
     PROMPT_TEMPLATE = """

--- a/patchwise/patch_review/ai_review/llm_learn_reviewer.py
+++ b/patchwise/patch_review/ai_review/llm_learn_reviewer.py
@@ -1,0 +1,248 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from git.objects.commit import Commit
+
+from patchwise import SANDBOX_PATH
+from patchwise.patch_review.decorators import register_llm_review
+from .ai_review import AiReview
+from .fetch_reviewer_comment import LoreCrawler
+
+@register_llm_review
+class LLMLearnReviewer(AiReview):
+
+    PROMPT_TEMPLATE = """
+Act as Linux kernel maintainer.
+
+=== REFERENCE CONTEXT (Past Reviews with Links - DO NOT REVIEW) ===
+-{reviewer_context}
+
+=== PATCH TO REVIEW (Immutable Target) ===
+-{commit_text}
+
+Instructions: Review the 'PATCH TO REVIEW' above.
+1. ONLY examine lines that start with `+` (additions) or `-` (deletions).
+2. Ignore all context lines (lines without `+` or `-` prefix) - they are just for reference.
+3. Find specific issues in the CHANGED lines only.
+4. Quote the problematic line exactly (with its `+` or `-` prefix) starting with `>`.
+5. Search the REFERENCE CONTEXT examples for similar issues.
+6. If a match is found:  Include the lore.kernel.org link from that example, Quote the relevant part of Suzuki's original comment, Explain the connection to the current issue.
+7. If no match, cite the relevant kernel standard.
+8. Remember: Only review what is being CHANGED (+ or - lines), not the surrounding context.
+"""
+
+    @classmethod
+    def get_system_prompt(cls) -> str:
+        """Generate the system prompt for the LLM."""
+        return """
+You are a rigorous Linux Kernel maintainer. Your task is to REVIEW the provided patch.
+
+=== CRITICAL RULE: PATCH INTEGRITY ===
+1. **IMMUTABLE INPUT**: You must treating the "PATCH TO REVIEW" section as read-only data.
+2. **VERBATIM QUOTING**: When you quote code to comment on it (using `>`), you must copy the line **EXACTLY** as it appears in the input. Do NOT fix typos in the quote. Do NOT change indentation. Do NOT add missing lines. Do NOT paraphrase.
+3. **NO HALLUCINATION**: If a line does not exist in the "PATCH TO REVIEW" text provided by the user, you are STRICTLY FORBIDDEN from quoting it.
+
+=== CRITICAL: FOCUS ON CHANGES ONLY ===
+YOU MUST ONLY REVIEW LINES THAT ARE BEING MODIFIED IN THE PATCH. In a unified diff format: Lines starting with `+` are ADDITIONS (new code being added). Lines starting with `-` are DELETIONS (old code being removed). Lines starting with ` ` (space) or no prefix are CONTEXT (unchanged code for reference).
+
+STRICT RULES:
+1. ONLY comment on lines with `+` or `-` prefixes - these are the actual changes.
+2. NEVER comment on context lines (lines without `+` or `-`) unless they directly relate to understanding a change.
+3. Focus your review on: New code being added (`+` lines), Code being removed (`-` lines) - check if the removal is safe, The interaction between additions and deletions.
+4. Ignore unchanged code - do not review existing code that is not being modified.
+
+Example of CORRECT review:
+> + spin_lock(&drvdata->lock);
+This new locking is problematic because...
+
+Example of INCORRECT review (DO NOT DO THIS):
+>   struct device *dev = &pdev->dev;
+This variable naming could be improved... (WRONG! This line has no `+` or `-`, it is just context.)
+
+=== REVIEW STYLE ===
+Format: Inline email reply. Quote the specific line(s) from the patch, then write your comment below. Tone: Direct, technical, constructive (mimicking the persona from "REFERENCE CONTEXT"). Content: Focus on logic errors, locking, memory safety, and kernel style in the changed lines only.
+
+=== JUSTIFICATION & REFERENCES (CRITICAL) ===
+When you flag an issue, you MUST provide concrete evidence for your reasoning:
+
+1. Pattern Matching (Priority): Search the "REFERENCE CONTEXT" examples for similar issues that Suzuki has previously commented on. Each example in the context contains: Title (The patch/thread title), Link (The lore.kernel.org URL), Code context (The original code being reviewed), Suzuki's comment (The actual review comment). If you find a matching pattern, cite it with full traceability: Include the link to the original discussion, Quote the relevant part of Suzuki's original comment, Explain how the current issue mirrors that past case.
+
+Example format: > + spin_lock(&drvdata->lock); This locking pattern is problematic.
+
+Similar issue was raised in Link: https://lore.kernel.org/linux-arm-kernel/...
+
+In that review, commented:
+"[Quote the relevant part from 'Suzuki's comment' field]"
+
+The same concern applies here - we need spin_lock_irqsave() to prevent deadlock with interrupt context.
+
+2. Kernel Standards (Fallback): If no matching pattern exists in the reference examples, cite general kernel rules: "This violates the RCU locking order documented in Documentation/RCU/", "This breaks the device model's probe/remove symmetry", "Per CodingStyle, function names should be verb phrases".
+
+3. No Vague Claims: NEVER say "this looks wrong" without backing it up. NEVER say "we usually do X" unless you can point to a specific example showing it. Always include the lore.kernel.org link when citing past reviews."""
+
+    def fetch_reviewer_comment(self) -> None:
+        # Check if reviewers list is empty to avoid division by zero
+        if not self.reviewers:
+            self.logger.warning("No reviewers found, skipping comment fetching")
+            return
+
+        self.logger.debug(f"Fetching reviewer comments for {len(self.reviewers)} reviewer(s)")
+        all_docs = []
+
+        # Process each reviewer
+        for idx, maintainer in enumerate(self.reviewers, 1):
+            self.logger.debug(f"Processing reviewer {idx}/{len(self.reviewers)}: {maintainer}")
+
+            # Update config for this maintainer
+            self.crawler_config["MAINTAINER"] = maintainer
+            limit_per_reviewer = self.crawler_config["MAX_COMMENT"] // len(self.reviewers)
+            self.crawler_config["LIMIT_PER_REVIEWER"] = limit_per_reviewer
+            # Initialize crawler for this maintainer
+            crawler = LoreCrawler(self.crawler_config, self.logger)
+
+            # Check for cached data
+            maintainer_name = maintainer.replace(" ", "_").replace("@", "_at_")
+            cache_file = os.path.join(SANDBOX_PATH, f"crawled_{maintainer_name}.json")
+            raw_docs = []
+
+            if os.path.exists(cache_file):
+                self.logger.debug(f"  Found cached data: {cache_file}")
+                try:
+                    with open(cache_file, 'r', encoding='utf-8') as f:
+                        cached_data = json.load(f)
+                        raw_docs = cached_data[:limit_per_reviewer]
+                        self.logger.debug(f"  Loaded {len(raw_docs)} cached records for {maintainer} (limited from {len(cached_data)})")
+                except Exception as e:
+                    self.logger.warning(f"  Failed to read cache: {e}, starting online crawling...")
+                    raw_docs = crawler.run()
+            else:
+                self.logger.debug(f"  No cache found, starting LoreCrawler for {maintainer}...")
+                raw_docs = crawler.run()
+
+            if raw_docs:
+                for doc in raw_docs:
+                    doc["maintainer"] = maintainer
+                all_docs.extend(raw_docs)
+                self.logger.debug(f"  ✓ Added {len(raw_docs)} items from {maintainer}")
+            else:
+                self.logger.warning(f"  Could not get reviewer data for {maintainer}")
+        if not all_docs:
+            self.logger.warning("Could not get any reviewer data from any reviewer")
+            return
+
+        self.logger.debug(f"✓ Total captured: {len(all_docs)} reviewer context items from {len(self.reviewers)} reviewer(s)")
+        self.reviewer_context = all_docs
+
+    def get_reviewers_from_maintainer_script(self, commit: Commit, repo_path: str) -> None:
+        """
+        Use the kernel's get_maintainer.pl script to find reviewers for a commit.
+        Args:
+            commit: The git commit object
+            repo_path: Path to the kernel repository
+        Returns:
+            List of reviewer names (without email addresses)
+        """
+        try:
+            # Create a temporary file for the patch
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.patch', delete=False) as tmp_file:
+                # Generate patch for the commit
+                patch_content = commit.repo.git.format_patch(
+                    '-1', commit.hexsha, '--stdout'
+                )
+                tmp_file.write(patch_content)
+                tmp_file_path = tmp_file.name
+    
+            # Path to get_maintainer.pl script
+            get_maintainer_script = Path(repo_path) / 'scripts' / 'get_maintainer.pl'
+    
+            if not get_maintainer_script.exists():
+                self.logger.warning(f"get_maintainer.pl script not found at {get_maintainer_script}")
+                self.reviewers = []
+                return
+    
+            # Run get_maintainer.pl script
+            result = subprocess.run(
+                ['perl', str(get_maintainer_script), tmp_file_path],
+                capture_output=True,
+                text=True,
+                cwd=repo_path
+            )
+    
+            # Clean up temporary file
+            Path(tmp_file_path).unlink(missing_ok=True)
+    
+            if result.returncode != 0:
+                self.logger.error(f"get_maintainer.pl failed: {result.stderr}")
+                self.reviewers = []
+                return
+    
+            # Parse output to extract reviewer names only
+            # Filter out mailing lists (lines containing "open list")
+            reviewers = []
+            for line in result.stdout.strip().split('\n'):
+                line = line.strip()
+                if line and 'list' not in line.lower():
+                    # get_maintainer.pl outputs lines like:
+                    # "Name <email@domain.com> (role)"
+                    # Extract only the name part before '<'
+                    name = line.split('<')[0].strip()
+                    # Remove any trailing quotes if present
+                    name = name.strip('"').strip("'").strip()
+                    if name:
+                        reviewers.append(name)
+    
+            self.reviewers = reviewers
+            self.logger.info(f"Found {len(reviewers)} reviewers: {reviewers}")
+    
+        except Exception as e:
+            self.logger.error(f"Error running get_maintainer.pl: {e}")
+            self.reviewers = []
+
+    def setup(self) -> None:
+        super().setup()
+
+        # Initialize crawler configuration
+        self.crawler_config = {
+            "MAINTAINER": "",  # Will be set per reviewer
+            "MAX_COMMENT": 20,  # Total comments to fetch across all reviewers
+            "PROXY": None,
+            "LIMIT_PER_REVIEWER": "",  # 0 means no limitation per crawler run
+            "NOISE_KEYWORDS": [
+                "applied", "applied, thanks", "applied, thanks.",
+                "queued", "queued for", "thanks", "thanks.",
+                "lgtm", "looks good to me",
+                "acked", "picked up", "merged", "fine", "cheers", "...", "^^^", "reviewed-by", "+1"
+            ],
+            "NOISE_TECH": ["should", "could", "need", "issue", "problem", "bug",
+                            "fix", "change", "modify", "suggest", "consider",
+                            "however", "but", "instead", "better", "improve"],
+            "NOISE_LENGTH": 100,
+            "MAX_CONTEXT_LINES": 40
+        }
+
+        # Initialize reviewers list
+        self.reviewers = []
+        self.reviewer_context = []
+
+    def run(self) -> str:
+        self.get_reviewers_from_maintainer_script(self.commit, self.repo.working_dir)
+        self.fetch_reviewer_comment()
+
+        formatted_prompt = LLMLearnReviewer.PROMPT_TEMPLATE.format(
+            diff=self.diff,
+            commit_text=str(self.commit_message),
+            reviewer_context=json.dumps(self.reviewer_context, indent=2) if self.reviewer_context else "No reviewer context available"
+        )
+
+        result = self.provider_api_call(
+            user_prompt=formatted_prompt,
+            system_prompt=self.get_system_prompt(),
+        )
+
+        return self.format_chat_response(result)

--- a/patchwise/patch_review/ai_review/llm_learn_reviewer.py
+++ b/patchwise/patch_review/ai_review/llm_learn_reviewer.py
@@ -18,44 +18,91 @@ from .fetch_reviewer_comment import LoreCrawler
 class LLMLearnReviewer(AiReview):
 
     PROMPT_TEMPLATE = """
-Act as Linux kernel maintainer.
+Act as a Linux kernel maintainer reviewing a patch submission.
 
-=== REFERENCE CONTEXT (Past Reviews with Links - DO NOT REVIEW) ===
--{reviewer_context}
+=== COMMIT INFORMATION ===
+{commit_message}
 
-=== PATCH TO REVIEW (Immutable Target) ===
--{commit_text}
+=== MAINTAINER'S REVIEW HISTORY (Learning Reference - DO NOT REVIEW) ===
+The following examples show how the maintainer(s) have reviewed similar patches in the past. 
+Study these carefully to understand:
+- What types of issues they commonly identify
+- Their review style and terminology
+- Common patterns they flag (locking issues, memory safety, error handling, etc.)
+- How they reference kernel standards and best practices
 
-Instructions: Review the 'PATCH TO REVIEW' above.
-1. ONLY examine lines that start with `+` (additions) or `-` (deletions).
-2. Ignore all context lines (lines without `+` or `-` prefix) - they are just for reference.
-3. Find specific issues in the CHANGED lines only.
-4. Quote the problematic line exactly (with its `+` or `-` prefix) starting with `>`.
-5. Search the REFERENCE CONTEXT examples for similar issues.
-6. If a match is found:  Include the lore.kernel.org link from that example, Quote the relevant part of Suzuki's original comment, Explain the connection to the current issue.
-7. If no match, cite the relevant kernel standard.
-8. Remember: Only review what is being CHANGED (+ or - lines), not the surrounding context.
+{reviewer_context}
+
+=== PATCH TO REVIEW ===
+{commit_content}
+
+=== REVIEW INSTRUCTIONS ===
+Your task is to review the PATCH above by learning from the MAINTAINER'S REVIEW HISTORY.
+
+1. **Focus on Changes Only**: 
+   - ONLY review lines starting with `+` (additions) or `-` (deletions)
+   - Context lines (no prefix or space prefix) are for reference only
+
+2. **Learn from History**:
+   - Analyze the review history to identify common concerns and patterns
+   - Look for similar code patterns, file types, or subsystems
+   - Adopt the maintainer's review style and focus areas
+   - Pay attention to recurring themes (e.g., locking, error paths, resource management)
+
+3. **Pattern Matching**:
+   - When you identify an issue, search the review history for similar cases
+   - If found, cite the specific example with its lore.kernel.org link
+   - Quote the relevant part of the maintainer's original comment
+   - Explain how the current issue relates to that past review
+
+4. **Provide Evidence**:
+   - Always back up your comments with either:
+     a) A reference to a similar issue from the review history (preferred)
+     b) A citation of kernel documentation or coding standards
+   - Never make vague claims without supporting evidence
+
+5. **Consider Commit Context**:
+   - Use the commit message to understand the patch's intent
+   - Verify that the changes align with the stated purpose
+   - Check if the implementation matches the description
+
+6. **Format Your Review**:
+   - Quote the specific problematic line(s) with `>` prefix
+   - Provide clear, technical, constructive feedback
+   - Include links to past reviews when citing similar issues
+
+7. **Be Concise for Correct Code**:
+   - If the patch looks correct with no issues, provide a brief positive acknowledgment
+   - Do NOT write lengthy explanations about why correct code is correct
+   - Example: "Looks good. The fix correctly addresses the clock imbalance issue."
+   - Only provide detailed analysis when you identify actual problems
 """
 
     @classmethod
     def get_system_prompt(cls) -> str:
         """Generate the system prompt for the LLM."""
         return """
-You are a rigorous Linux Kernel maintainer. Your task is to REVIEW the provided patch.
+You are an experienced Linux Kernel maintainer conducting a code review. Your expertise comes from studying how maintainers review patches in practice.
+
+=== YOUR ROLE ===
+Learn from the maintainer's review history to understand their focus areas, common concerns, and review style. Apply these learned patterns to review new patches with the same rigor and attention to detail.
 
 === CRITICAL RULE: PATCH INTEGRITY ===
-1. **IMMUTABLE INPUT**: You must treating the "PATCH TO REVIEW" section as read-only data.
-2. **VERBATIM QUOTING**: When you quote code to comment on it (using `>`), you must copy the line **EXACTLY** as it appears in the input. Do NOT fix typos in the quote. Do NOT change indentation. Do NOT add missing lines. Do NOT paraphrase.
-3. **NO HALLUCINATION**: If a line does not exist in the "PATCH TO REVIEW" text provided by the user, you are STRICTLY FORBIDDEN from quoting it.
+1. **IMMUTABLE INPUT**: Treat the "PATCH TO REVIEW" section as read-only data.
+2. **VERBATIM QUOTING**: When quoting code (using `>`), copy the line **EXACTLY** as it appears. Do NOT fix typos, change indentation, add missing lines, or paraphrase.
+3. **NO HALLUCINATION**: If a line does not exist in the patch, you are STRICTLY FORBIDDEN from quoting it.
 
 === CRITICAL: FOCUS ON CHANGES ONLY ===
-YOU MUST ONLY REVIEW LINES THAT ARE BEING MODIFIED IN THE PATCH. In a unified diff format: Lines starting with `+` are ADDITIONS (new code being added). Lines starting with `-` are DELETIONS (old code being removed). Lines starting with ` ` (space) or no prefix are CONTEXT (unchanged code for reference).
+In unified diff format:
+- Lines starting with `+` are ADDITIONS (new code being added)
+- Lines starting with `-` are DELETIONS (old code being removed)  
+- Lines starting with ` ` (space) or no prefix are CONTEXT (unchanged code for reference)
 
 STRICT RULES:
-1. ONLY comment on lines with `+` or `-` prefixes - these are the actual changes.
-2. NEVER comment on context lines (lines without `+` or `-`) unless they directly relate to understanding a change.
-3. Focus your review on: New code being added (`+` lines), Code being removed (`-` lines) - check if the removal is safe, The interaction between additions and deletions.
-4. Ignore unchanged code - do not review existing code that is not being modified.
+1. ONLY comment on lines with `+` or `-` prefixes - these are the actual changes
+2. NEVER comment on context lines unless they directly relate to understanding a change
+3. Focus on: New code being added (`+` lines), Code being removed (`-` lines), Interactions between additions and deletions
+4. Ignore unchanged code that is not being modified
 
 Example of CORRECT review:
 > + spin_lock(&drvdata->lock);
@@ -65,26 +112,86 @@ Example of INCORRECT review (DO NOT DO THIS):
 >   struct device *dev = &pdev->dev;
 This variable naming could be improved... (WRONG! This line has no `+` or `-`, it is just context.)
 
-=== REVIEW STYLE ===
-Format: Inline email reply. Quote the specific line(s) from the patch, then write your comment below. Tone: Direct, technical, constructive (mimicking the persona from "REFERENCE CONTEXT"). Content: Focus on logic errors, locking, memory safety, and kernel style in the changed lines only.
+=== LEARNING FROM REVIEW HISTORY ===
+The user prompt contains a "MAINTAINER'S REVIEW HISTORY" section with past reviews. Use this to:
 
-=== JUSTIFICATION & REFERENCES (CRITICAL) ===
-When you flag an issue, you MUST provide concrete evidence for your reasoning:
+1. **Identify Common Patterns**: What issues does the maintainer frequently catch?
+   - Locking problems (missing locks, wrong lock types, deadlock risks)
+   - Memory safety (leaks, use-after-free, buffer overflows)
+   - Error handling (missing checks, incorrect cleanup paths)
+   - Race conditions and concurrency issues
+   - API misuse or violations of kernel conventions
 
-1. Pattern Matching (Priority): Search the "REFERENCE CONTEXT" examples for similar issues that Suzuki has previously commented on. Each example in the context contains: Title (The patch/thread title), Link (The lore.kernel.org URL), Code context (The original code being reviewed), Suzuki's comment (The actual review comment). If you find a matching pattern, cite it with full traceability: Include the link to the original discussion, Quote the relevant part of Suzuki's original comment, Explain how the current issue mirrors that past case.
+2. **Understand Review Style**: How does the maintainer communicate?
+   - Tone and language used
+   - Level of detail in explanations
+   - How they reference documentation or past discussions
 
-Example format: > + spin_lock(&drvdata->lock); This locking pattern is problematic.
+3. **Learn Focus Areas**: What does the maintainer care most about?
+   - Specific subsystems or file types
+   - Particular coding patterns or anti-patterns
+   - Performance, security, or maintainability concerns
 
-Similar issue was raised in Link: https://lore.kernel.org/linux-arm-kernel/...
+=== PROVIDING EVIDENCE-BASED REVIEWS ===
+When you identify an issue, you MUST provide concrete evidence:
 
-In that review, commented:
-"[Quote the relevant part from 'Suzuki's comment' field]"
+**Priority 1 - Pattern Matching from History**:
+Search the review history for similar issues. Each example contains:
+- `content`: The code context being reviewed
+- `comment`: The maintainer's review comment
+- `title`: The patch/thread title
+- `link`: The lore.kernel.org URL
+- `file_path`: The file being reviewed (if available)
+- `maintainer`: The reviewer's name
+
+If you find a matching pattern, cite it with full traceability:
+
+Example format:
+> + spin_lock(&drvdata->lock);
+This locking pattern is problematic.
+
+Similar issue was previously identified in:
+Link: https://lore.kernel.org/linux-arm-kernel/...
+
+The maintainer commented:
+"[Quote the relevant part from the 'comment' field]"
 
 The same concern applies here - we need spin_lock_irqsave() to prevent deadlock with interrupt context.
 
-2. Kernel Standards (Fallback): If no matching pattern exists in the reference examples, cite general kernel rules: "This violates the RCU locking order documented in Documentation/RCU/", "This breaks the device model's probe/remove symmetry", "Per CodingStyle, function names should be verb phrases".
+**Priority 2 - Kernel Standards (Fallback)**:
+If no matching pattern exists in the review history, cite general kernel rules:
+- "This violates the RCU locking order documented in Documentation/RCU/"
+- "This breaks the device model's probe/remove symmetry"
+- "Per CodingStyle, function names should be verb phrases"
 
-3. No Vague Claims: NEVER say "this looks wrong" without backing it up. NEVER say "we usually do X" unless you can point to a specific example showing it. Always include the lore.kernel.org link when citing past reviews."""
+**Never Make Vague Claims**:
+- NEVER say "this looks wrong" without backing it up
+- NEVER say "we usually do X" unless you can point to a specific example
+- Always include the lore.kernel.org link when citing past reviews
+
+=== REVIEW FORMAT ===
+- **Style**: Inline email reply format
+- **Structure**: Quote specific line(s) from the patch, then write your comment below
+- **Tone**: Direct, technical, constructive (mimic the maintainer's style from the review history)
+- **Content**: Focus on logic errors, locking, memory safety, and kernel style in changed lines only
+
+=== BREVITY FOR CORRECT CODE ===
+**CRITICAL**: When the patch looks correct with no issues:
+- Provide a brief, positive acknowledgment (1-2 sentences maximum)
+- Do NOT write lengthy explanations about why correct code is correct
+- Do NOT quote correct code and explain why it's correct
+- Examples of good responses:
+  * "Looks good."
+  * "The fix correctly addresses the issue."
+  * "No issues found."
+- Save detailed analysis ONLY for when you identify actual problems
+
+=== COMMIT MESSAGE CONTEXT ===
+Use the commit message to:
+- Understand the patch's intent and purpose
+- Verify that changes align with the stated goal
+- Check if the implementation matches the description
+- Identify any discrepancies between what's claimed and what's implemented"""
 
     def fetch_reviewer_comment(self) -> None:
         # Check if reviewers list is empty to avoid division by zero
@@ -234,9 +341,12 @@ The same concern applies here - we need spin_lock_irqsave() to prevent deadlock 
         self.get_reviewers_from_maintainer_script(self.commit, self.repo.working_dir)
         self.fetch_reviewer_comment()
 
+        # Extract commit message for context
+        commit_message = f"Subject: {self.commit.summary}\n\n{self.commit.message}"
+
         formatted_prompt = LLMLearnReviewer.PROMPT_TEMPLATE.format(
-            diff=self.diff,
-            commit_text=str(self.commit_message),
+            commit_message=commit_message,
+            commit_content=self.diff,
             reviewer_context=json.dumps(self.reviewer_context, indent=2) if self.reviewer_context else "No reviewer context available"
         )
 

--- a/patchwise/patch_review/ai_review/llm_learn_reviewer.py
+++ b/patchwise/patch_review/ai_review/llm_learn_reviewer.py
@@ -1,6 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import argparse
 import json
 import os
 import subprocess
@@ -14,8 +15,13 @@ from patchwise.patch_review.decorators import register_patch_review
 from .ai_review import AiReview
 from .fetch_reviewer_comment import DEFAULT_SOURCE_URL, LoreCrawler
 
+DEFAULT_CACHE_DIR = str(SANDBOX_PATH)
+
+
 @register_patch_review
 class LLMLearnReviewer(AiReview):
+    lore_url: str = DEFAULT_SOURCE_URL
+    cache_dir: str = DEFAULT_CACHE_DIR
 
     PROMPT_TEMPLATE = """
 Act as a Linux kernel maintainer reviewing a patch submission.
@@ -314,17 +320,18 @@ Use the commit message to:
     def setup(self) -> None:
         super().setup()
 
-        # Initialize crawler configuration. SOURCE_URL and CACHE_DIR can be
-        # overridden via PATCHWISE_LORE_URL / PATCHWISE_CACHE_DIR env vars so
-        # users can crawl an internal mirror or store the (potentially large)
-        # cache outside /tmp without code changes.
+        # Initialize crawler configuration. SOURCE_URL and CACHE_DIR come from
+        # the --url and --cache_dir command-line flags (see
+        # add_llmlearn_arguments) so users can crawl an internal mirror or
+        # store the (potentially large) cache outside /tmp without code
+        # changes.
         self.crawler_config = {
             "MAINTAINER": "",  # Will be set per reviewer
             "MAX_COMMENT": 20,  # Total comments to fetch across all reviewers
             "PROXY": None,
             "LIMIT_PER_REVIEWER": "",  # 0 means no limitation per crawler run
-            "SOURCE_URL": os.environ.get("PATCHWISE_LORE_URL", DEFAULT_SOURCE_URL),
-            "CACHE_DIR": os.environ.get("PATCHWISE_CACHE_DIR", str(SANDBOX_PATH)),
+            "SOURCE_URL": LLMLearnReviewer.lore_url,
+            "CACHE_DIR": LLMLearnReviewer.cache_dir,
             "NOISE_KEYWORDS": [
                 "applied", "applied, thanks", "applied, thanks.",
                 "queued", "queued for", "thanks", "thanks.",
@@ -361,3 +368,27 @@ Use the commit message to:
         )
 
         return self.format_chat_response(result)
+
+
+def add_llmlearn_arguments(
+    parser_or_group: argparse.ArgumentParser | argparse._ArgumentGroup,
+):
+    parser_or_group.add_argument(
+        "--url",
+        default=DEFAULT_SOURCE_URL,
+        help="Lore archive base URL used by LLMLearnReviewer to fetch maintainer review history. (default: %(default)s)",
+    )
+    parser_or_group.add_argument(
+        "--cache_dir",
+        default=DEFAULT_CACHE_DIR,
+        help="Directory where LLMLearnReviewer caches crawled reviewer comments. (default: %(default)s)",
+    )
+
+
+def apply_llmlearn_args(args: argparse.Namespace) -> None:
+    """
+    Applies LLMLearnReviewer-related arguments to the class.
+    Called after parsing command line arguments.
+    """
+    LLMLearnReviewer.lore_url = args.url
+    LLMLearnReviewer.cache_dir = args.cache_dir

--- a/patchwise/patch_review/ai_review/llm_learn_reviewer.py
+++ b/patchwise/patch_review/ai_review/llm_learn_reviewer.py
@@ -12,7 +12,7 @@ from git.objects.commit import Commit
 from patchwise import SANDBOX_PATH
 from patchwise.patch_review.decorators import register_patch_review
 from .ai_review import AiReview
-from .fetch_reviewer_comment import LoreCrawler
+from .fetch_reviewer_comment import DEFAULT_SOURCE_URL, LoreCrawler
 
 @register_patch_review
 class LLMLearnReviewer(AiReview):
@@ -215,7 +215,7 @@ Use the commit message to:
 
             # Check for cached data
             maintainer_name = maintainer.replace(" ", "_").replace("@", "_at_")
-            cache_file = os.path.join(SANDBOX_PATH, f"crawled_{maintainer_name}.json")
+            cache_file = os.path.join(self.crawler_config["CACHE_DIR"], f"crawled_{maintainer_name}.json")
             raw_docs = []
 
             if os.path.exists(cache_file):
@@ -314,12 +314,17 @@ Use the commit message to:
     def setup(self) -> None:
         super().setup()
 
-        # Initialize crawler configuration
+        # Initialize crawler configuration. SOURCE_URL and CACHE_DIR can be
+        # overridden via PATCHWISE_LORE_URL / PATCHWISE_CACHE_DIR env vars so
+        # users can crawl an internal mirror or store the (potentially large)
+        # cache outside /tmp without code changes.
         self.crawler_config = {
             "MAINTAINER": "",  # Will be set per reviewer
             "MAX_COMMENT": 20,  # Total comments to fetch across all reviewers
             "PROXY": None,
             "LIMIT_PER_REVIEWER": "",  # 0 means no limitation per crawler run
+            "SOURCE_URL": os.environ.get("PATCHWISE_LORE_URL", DEFAULT_SOURCE_URL),
+            "CACHE_DIR": os.environ.get("PATCHWISE_CACHE_DIR", str(SANDBOX_PATH)),
             "NOISE_KEYWORDS": [
                 "applied", "applied, thanks", "applied, thanks.",
                 "queued", "queued for", "thanks", "thanks.",

--- a/patchwise/patch_review/ai_review/llm_learn_reviewer.py
+++ b/patchwise/patch_review/ai_review/llm_learn_reviewer.py
@@ -375,20 +375,23 @@ def add_llmlearn_arguments(
 ):
     parser_or_group.add_argument(
         "--url",
-        default=DEFAULT_SOURCE_URL,
-        help="Lore archive base URL used by LLMLearnReviewer to fetch maintainer review history. (default: %(default)s)",
+        default=None,
+        help=f"Lore archive base URL used by LLMLearnReviewer to fetch maintainer review history. Only valid with --reviews llmlearnreviewer. (default: {DEFAULT_SOURCE_URL})",
     )
     parser_or_group.add_argument(
         "--cache_dir",
-        default=DEFAULT_CACHE_DIR,
-        help="Directory where LLMLearnReviewer caches crawled reviewer comments. (default: %(default)s)",
+        default=None,
+        help=f"Directory where LLMLearnReviewer caches crawled reviewer comments. Only valid with --reviews llmlearnreviewer. (default: {DEFAULT_CACHE_DIR})",
     )
 
 
 def apply_llmlearn_args(args: argparse.Namespace) -> None:
     """
     Applies LLMLearnReviewer-related arguments to the class.
-    Called after parsing command line arguments.
+    Called after parsing command line arguments. Values left as None
+    (i.e. the user did not pass the flag) keep the class defaults.
     """
-    LLMLearnReviewer.lore_url = args.url
-    LLMLearnReviewer.cache_dir = args.cache_dir
+    if args.url is not None:
+        LLMLearnReviewer.lore_url = args.url
+    if args.cache_dir is not None:
+        LLMLearnReviewer.cache_dir = args.cache_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "pytest>=8.3.5",
     "rich-argparse>=1.7.0",
     "tqdm>=4.67.1",
-    "platformdirs>=4.3.8"
+    "platformdirs>=4.3.8",
+    "requests>=2.31.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
**Purpose / Motivation**
Problem Statement
Traditional AI code reviewers often provide generic feedback that doesn't align with specific maintainer preferences or project conventions. Kernel maintainers have unique review styles, focus areas, and recurring concerns that are difficult to capture in static prompts.

**Solution**
LLM Learn Reviewer is an intelligent code review system that learns from historical maintainer reviews to provide contextually relevant, evidence-based feedback. By analyzing past review patterns from lore.kernel.org, it mimics the review style and focus areas of actual kernel maintainers.

**System Components:**
```
┌─────────────────────────────────────────────────────────────┐
│                    LLMLearnReviewer                         │
│  (Main orchestrator - inherits from AiReview)               │
└────────────┬────────────────────────────────────────────────┘
             │
             ├─► get_maintainer.pl ──► Identify relevant reviewers
             │
             ├─► LoreCrawler ──────────► Fetch historical reviews
             │                           │
             │                           ├─► Search lore.kernel.org
             │                           ├─► Parse email threads
             │                           ├─► Extract code context
             │                           └─► Cache results locally
             │
             └─► LLM Provider ─────────► Generate review
                 (Claude/GPT)            │
                                         ├─► Pattern matching
                                         ├─► Evidence citation
                                         └─► Formatted feedback
```
 **Usage Guide**
```
patchwise --reviews LLMLearnReviewer 
```
**Configuration**
```
crawler_config = {
    "MAINTAINER": "",              # Set per reviewer automatically
    "MAX_COMMENT": 20,             # Total comments across all reviewers
    "LIMIT_PER_REVIEWER": "",      # Calculated: MAX_COMMENT / num_reviewers
    "PROXY": None,                 # Optional HTTP/HTTPS proxy
    "NOISE_KEYWORDS": [...],       # Filter out non-technical comments
    "NOISE_LENGTH": 100,           # Minimum comment length threshold
    "MAX_CONTEXT_LINES": 40        # Max lines of code context per segment
}
```

**Example Output**
```
> + spin_lock(&drvdata->lock);
This locking pattern is problematic. The lock is acquired in process context
but the same data structure is accessed in interrupt handlers.

Similar issue was previously identified in:
Link: https://lore.kernel.org/linux-arm-kernel/20231015123456.GA12345@kernel.org

The maintainer commented:
"You need spin_lock_irqsave() here because this can be called from both
process and interrupt context. Using spin_lock() will cause a deadlock
if an interrupt fires while holding the lock."

The same concern applies here - we need spin_lock_irqsave() to prevent
deadlock with interrupt context.
```
