### PR TITLE
Feature - save patch review results to individual output files per commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ MANIFEST
 sandbox/
 tests/linux/
 
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ MANIFEST
 sandbox/
 tests/linux/
 
-venv/

--- a/patchwise/__init__.py
+++ b/patchwise/__init__.py
@@ -18,5 +18,10 @@ SANDBOX_BIN = SANDBOX_PATH / "bin"
 # Define the kernel workspace path
 KERNEL_PATH = SANDBOX_PATH / "kernel"
 
+# Define the output directory path
+_default_output = Path("/tmp") / PACKAGE_NAME / "output"
+OUTPUT_PATH = Path(os.environ.get("PATCHWISE_OUTPUT_PATH", str(_default_output)))
+
 # Ensure the sandbox directory exists
 SANDBOX_PATH.mkdir(parents=True, exist_ok=True)
+OUTPUT_PATH.mkdir(parents=True, exist_ok=True)

--- a/patchwise/main.py
+++ b/patchwise/main.py
@@ -9,6 +9,7 @@ from git import Repo
 from git.objects.commit import Commit
 from rich_argparse import RichHelpFormatter
 
+from patchwise import OUTPUT_PATH
 from .logger_setup import add_logging_arguments, setup_logger
 from .patch_review import (
     add_review_arguments,
@@ -46,6 +47,13 @@ def parse_args(config: dict) -> argparse.Namespace:
 
     logging_group = parser.add_argument_group("Logging Options")
     add_logging_arguments(logging_group, config)
+
+    output_group = parser.add_argument_group("Output Options")
+    output_group.add_argument(
+        "--output-dir",
+        default=str(OUTPUT_PATH),
+        help="Directory to save the review results. (default: %(default)s)",
+    )
 
     return parser.parse_args()
 
@@ -101,7 +109,17 @@ def main():
 
     for commit in commits:
         logger.info(f"Reviewing commit {commit.hexsha}...")
-        review_commit(reviews, commit, args.repo_path)
+        results = review_commit(reviews, commit, args.repo_path)
+        
+        # Save results to output directory
+        output_dir = Path(args.output_dir) / commit.hexsha
+        output_dir.mkdir(parents=True, exist_ok=True)
+        
+        for review_name, result_text in results.results.items():
+            output_file = output_dir / f"{review_name.lower()}.txt"
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(result_text if result_text else "No issues found\n")
+            logger.debug(f"Saved {review_name} results to {output_file}")
 
 
 if __name__ == "__main__":

--- a/patchwise/main.py
+++ b/patchwise/main.py
@@ -119,7 +119,7 @@ def main():
             output_file = output_dir / f"{review_name.lower()}.txt"
             with open(output_file, "w", encoding="utf-8") as f:
                 f.write(result_text if result_text else "No issues found\n")
-            logger.debug(f"Saved {review_name} results to {output_file}")
+            logger.info(f"Saved {review_name} results to {output_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ref issue #54 

Right now, results just print to stdout and `patchwise.log`. If you're running multiple checks on a few commits, trying to hunt down the output for a specific review on a specific commit is pretty annoying. 

**Solution**
I updated the script so it automatically dumps the output of each patch review into its own text file. 

Basically, I:
- Added an `--output-dir` flag (defaults to `/tmp/patchwise/output`).
- Changed `main.py` so it grabs the return value from `review_commit`.
- Made it create a directory for each commit (like `/tmp/patchwise/output/sha123/`).
- Made it write each review's output to a file like `coccicheck.txt` or `aicodereview.txt` in that commit's folder. (If a review passes with no issues, it just writes "No issues found" to the file).

This doesn't break anything—all the original stdout and logging still works exactly the same as before. Tests and lints are still passing.
