### PR TITLE
Agent: add git tools for AI to navigate commit history

### DIFF
--- a/patchwise/docker.py
+++ b/patchwise/docker.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
-import os
 import subprocess
 import time
 from pathlib import Path
@@ -39,14 +38,6 @@ class DockerManager:
     def _container_path(path: Path | str) -> str:
         """Normalize a container path to POSIX form for Docker CLI calls."""
         return str(path).replace("\\", "/")
-
-    def _use_kernel_overlay(self) -> bool:
-        """Overlay-backed kernel mounts are unreliable under Windows Docker."""
-        return os.name != "nt"
-
-    def _using_bind_mounted_kernel(self) -> bool:
-        """True when the container sees the host repo directly instead of an overlay."""
-        return not self._use_kernel_overlay()
 
     @property
     def _kernel_volume_name(self) -> str:
@@ -219,16 +210,13 @@ class DockerManager:
 
     def start_container(self, build_path: Path) -> None:
         """Legacy method for backward compatibility. Use start_container_with_shared_volume instead."""
-        kernel_mount_source = str(self.repo_path)
-        if self._use_kernel_overlay():
-            try:
-                self._kernel_overlay_volume = self._setup_kernel_overlay()
-                kernel_mount_source = self._kernel_overlay_volume
-            except subprocess.CalledProcessError as e:
-                self.logger.error(
-                    f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
-                )
-                raise
+        try:
+            self._kernel_overlay_volume = self._setup_kernel_overlay()
+        except subprocess.CalledProcessError as e:
+            self.logger.error(
+                f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
+            )
+            raise
 
         try:
             subprocess.run(
@@ -247,7 +235,7 @@ class DockerManager:
                 "-v",
                 f"{build_path}:{self._container_path(self.build_dir)}",
                 "-v",
-                f"{kernel_mount_source}:{self._container_path(self.kernel_dir)}",
+                f"{self._kernel_overlay_volume}:{self._container_path(self.kernel_dir)}",
                 self.image_tag,
                 "tail",
                 "-f",
@@ -266,8 +254,7 @@ class DockerManager:
                 self.logger.info(
                     f"Failed to start container {self.container_name}: {e}\nstderr: {e.stderr}"
                 )
-                if self._kernel_overlay_volume:
-                    self._cleanup_kernel_overlay()
+                self._cleanup_kernel_overlay()
                 raise
             self.logger.info(f"Container {self.container_name} started successfully.")
 
@@ -277,8 +264,7 @@ class DockerManager:
                 self.logger.error(
                     f"Failed to prepare kernel tree at {self.commit_sha}: {e}\nstderr: {e.stderr}"
                 )
-                if self._kernel_overlay_volume:
-                    self._cleanup_kernel_overlay()
+                self._cleanup_kernel_overlay()
                 raise
 
     def run_command(
@@ -488,8 +474,7 @@ class DockerManager:
             )
             raise
         finally:
-            if self._kernel_overlay_volume:
-                self._cleanup_kernel_overlay()
+            self._cleanup_kernel_overlay()
 
     @classmethod
     def create_shared_build_volume(cls) -> None:
@@ -602,16 +587,13 @@ class DockerManager:
 
     def start_container_with_shared_volume(self) -> None:
         """Start container with the shared build volume instead of bind mount."""
-        kernel_mount_source = str(self.repo_path)
-        if self._use_kernel_overlay():
-            try:
-                self._kernel_overlay_volume = self._setup_kernel_overlay()
-                kernel_mount_source = self._kernel_overlay_volume
-            except subprocess.CalledProcessError as e:
-                self.logger.error(
-                    f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
-                )
-                raise
+        try:
+            self._kernel_overlay_volume = self._setup_kernel_overlay()
+        except subprocess.CalledProcessError as e:
+            self.logger.error(
+                f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
+            )
+            raise
 
         try:
             subprocess.run(
@@ -632,7 +614,7 @@ class DockerManager:
                 "-v",
                 f"{self._build_volume_name}:{self._container_path(self.build_dir)}",
                 "-v",
-                f"{kernel_mount_source}:{self._container_path(self.kernel_dir)}",
+                f"{self._kernel_overlay_volume}:{self._container_path(self.kernel_dir)}",
                 self.image_tag,
                 "tail",
                 "-f",
@@ -651,8 +633,7 @@ class DockerManager:
                 self.logger.info(
                     f"Failed to start container {self.container_name}: {e}\nstderr: {e.stderr}"
                 )
-                if self._kernel_overlay_volume:
-                    self._cleanup_kernel_overlay()
+                self._cleanup_kernel_overlay()
                 raise
             self.logger.info(f"Container {self.container_name} started successfully.")
 
@@ -663,8 +644,7 @@ class DockerManager:
                 self.logger.error(
                     f"Failed to fix build directory permissions: {e}\nstderr: {e.stderr}"
                 )
-                if self._kernel_overlay_volume:
-                    self._cleanup_kernel_overlay()
+                self._cleanup_kernel_overlay()
                 raise
 
             try:
@@ -673,8 +653,7 @@ class DockerManager:
                 self.logger.error(
                     f"Failed to prepare kernel tree at {self.commit_sha}: {e}\nstderr: {e.stderr}"
                 )
-                if self._kernel_overlay_volume:
-                    self._cleanup_kernel_overlay()
+                self._cleanup_kernel_overlay()
                 raise
 
     def _prepare_kernel_tree(self) -> None:
@@ -701,16 +680,6 @@ class DockerManager:
             check=True,
             capture_output=True,
         )
-
-        # On Windows we bind-mount the host kernel tree directly because the
-        # overlay-volume approach is not reliable under Docker Desktop. Large
-        # git reset/clean sweeps over that bind mount are extremely slow and
-        # can stall fixture setup for a long time, so leave the tree as-is.
-        if self._using_bind_mounted_kernel():
-            self.logger.debug(
-                "Using bind-mounted kernel tree; skipping reset/clean/chown preparation."
-            )
-            return
 
         subprocess.run(
             [

--- a/patchwise/docker.py
+++ b/patchwise/docker.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -32,6 +33,20 @@ class DockerManager:
         self.sandbox_path = Path("/home") / PACKAGE_NAME
         self.build_dir = self.sandbox_path / "build"
         self.kernel_dir = self.sandbox_path / "kernel"
+        self._kernel_overlay_volume: Optional[str] = None
+
+    @staticmethod
+    def _container_path(path: Path | str) -> str:
+        """Normalize a container path to POSIX form for Docker CLI calls."""
+        return str(path).replace("\\", "/")
+
+    def _use_kernel_overlay(self) -> bool:
+        """Overlay-backed kernel mounts are unreliable under Windows Docker."""
+        return os.name != "nt"
+
+    def _using_bind_mounted_kernel(self) -> bool:
+        """True when the container sees the host repo directly instead of an overlay."""
+        return not self._use_kernel_overlay()
 
     @property
     def _kernel_volume_name(self) -> str:
@@ -204,13 +219,16 @@ class DockerManager:
 
     def start_container(self, build_path: Path) -> None:
         """Legacy method for backward compatibility. Use start_container_with_shared_volume instead."""
-        try:
-            self._kernel_overlay_volume = self._setup_kernel_overlay()
-        except subprocess.CalledProcessError as e:
-            self.logger.error(
-                f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
-            )
-            raise
+        kernel_mount_source = str(self.repo_path)
+        if self._use_kernel_overlay():
+            try:
+                self._kernel_overlay_volume = self._setup_kernel_overlay()
+                kernel_mount_source = self._kernel_overlay_volume
+            except subprocess.CalledProcessError as e:
+                self.logger.error(
+                    f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
+                )
+                raise
 
         try:
             subprocess.run(
@@ -227,9 +245,9 @@ class DockerManager:
                 "--name",
                 self.container_name,
                 "-v",
-                f"{build_path}:{self.build_dir}",
+                f"{build_path}:{self._container_path(self.build_dir)}",
                 "-v",
-                f"{self._kernel_overlay_volume}:{self.kernel_dir}",
+                f"{kernel_mount_source}:{self._container_path(self.kernel_dir)}",
                 self.image_tag,
                 "tail",
                 "-f",
@@ -248,7 +266,8 @@ class DockerManager:
                 self.logger.info(
                     f"Failed to start container {self.container_name}: {e}\nstderr: {e.stderr}"
                 )
-                self._cleanup_kernel_overlay()
+                if self._kernel_overlay_volume:
+                    self._cleanup_kernel_overlay()
                 raise
             self.logger.info(f"Container {self.container_name} started successfully.")
 
@@ -258,14 +277,17 @@ class DockerManager:
                 self.logger.error(
                     f"Failed to prepare kernel tree at {self.commit_sha}: {e}\nstderr: {e.stderr}"
                 )
-                self._cleanup_kernel_overlay()
+                if self._kernel_overlay_volume:
+                    self._cleanup_kernel_overlay()
                 raise
 
     def run_command(
         self, command: list[str], cwd: Optional[str], **kwargs: Any
     ) -> subprocess.Popen[str]:
         if not cwd:
-            cwd = str(self.sandbox_path)
+            cwd = self._container_path(self.sandbox_path)
+        else:
+            cwd = self._container_path(cwd)
 
         docker_command = ["docker", "exec"]
         docker_command.extend(["--workdir", cwd])
@@ -287,7 +309,9 @@ class DockerManager:
     ) -> subprocess.Popen[str]:
         """Run an interactive command that needs stdin/stdout communication."""
         if not cwd:
-            cwd = str(self.sandbox_path)
+            cwd = self._container_path(self.sandbox_path)
+        else:
+            cwd = self._container_path(cwd)
 
         docker_command = ["docker", "exec", "-i"]
         docker_command.extend(["--workdir", cwd])
@@ -324,7 +348,8 @@ class DockerManager:
 
         # Create index directory in container
         create_proc = self.run_command(
-            ["mkdir", "-p", str(index_dir)], cwd=str(self.build_dir)
+            ["mkdir", "-p", self._container_path(index_dir)],
+            cwd=self._container_path(self.build_dir),
         )
         create_proc.wait()
 
@@ -344,7 +369,7 @@ class DockerManager:
                     "chown",
                     "-R",
                     "patchwise:patchwise",
-                    str(index_dir),
+                    self._container_path(index_dir),
                 ],
                 check=True,
                 capture_output=True,
@@ -360,7 +385,7 @@ class DockerManager:
                     "chmod",
                     "-R",
                     "755",
-                    str(index_dir),
+                    self._container_path(index_dir),
                 ],
                 check=True,
                 capture_output=True,
@@ -379,7 +404,9 @@ class DockerManager:
     ) -> subprocess.Popen[str]:
         """Start clangd via docker exec with direct stdin/stdout communication."""
         if not cwd:
-            cwd = str(self.kernel_dir)
+            cwd = self._container_path(self.kernel_dir)
+        else:
+            cwd = self._container_path(cwd)
 
         # Ensure index directory exists
         self.ensure_clangd_index_dir()
@@ -461,7 +488,8 @@ class DockerManager:
             )
             raise
         finally:
-            self._cleanup_kernel_overlay()
+            if self._kernel_overlay_volume:
+                self._cleanup_kernel_overlay()
 
     @classmethod
     def create_shared_build_volume(cls) -> None:
@@ -527,7 +555,8 @@ class DockerManager:
                 capture_output=True,
             )
 
-            # Run the initialization script as root
+            # Initialize the shared volume inline instead of depending on a
+            # helper script being present in the image.
             subprocess.run(
                 [
                     "docker",
@@ -535,7 +564,16 @@ class DockerManager:
                     "--user",
                     "root",
                     init_container_name,
-                    "/home/patchwise/init-build-dir.sh",
+                    "sh",
+                    "-lc",
+                    (
+                        "set -e; "
+                        "echo 'Initializing shared build directory...'; "
+                        "mkdir -p /shared/build; "
+                        "chown -R patchwise:patchwise /shared/build; "
+                        "chmod -R 755 /shared/build; "
+                        "echo 'Build directory initialized successfully'"
+                    ),
                 ],
                 check=True,
                 capture_output=True,
@@ -564,13 +602,16 @@ class DockerManager:
 
     def start_container_with_shared_volume(self) -> None:
         """Start container with the shared build volume instead of bind mount."""
-        try:
-            self._kernel_overlay_volume = self._setup_kernel_overlay()
-        except subprocess.CalledProcessError as e:
-            self.logger.error(
-                f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
-            )
-            raise
+        kernel_mount_source = str(self.repo_path)
+        if self._use_kernel_overlay():
+            try:
+                self._kernel_overlay_volume = self._setup_kernel_overlay()
+                kernel_mount_source = self._kernel_overlay_volume
+            except subprocess.CalledProcessError as e:
+                self.logger.error(
+                    f"Failed to create kernel overlay volume: {e}\nstderr:{e.stderr}"
+                )
+                raise
 
         try:
             subprocess.run(
@@ -589,9 +630,9 @@ class DockerManager:
                 "-v",
                 f"{self._build_volume_name}:/shared/build",
                 "-v",
-                f"{self._build_volume_name}:{self.build_dir}",
+                f"{self._build_volume_name}:{self._container_path(self.build_dir)}",
                 "-v",
-                f"{self._kernel_overlay_volume}:{self.kernel_dir}",
+                f"{kernel_mount_source}:{self._container_path(self.kernel_dir)}",
                 self.image_tag,
                 "tail",
                 "-f",
@@ -610,7 +651,8 @@ class DockerManager:
                 self.logger.info(
                     f"Failed to start container {self.container_name}: {e}\nstderr: {e.stderr}"
                 )
-                self._cleanup_kernel_overlay()
+                if self._kernel_overlay_volume:
+                    self._cleanup_kernel_overlay()
                 raise
             self.logger.info(f"Container {self.container_name} started successfully.")
 
@@ -621,7 +663,8 @@ class DockerManager:
                 self.logger.error(
                     f"Failed to fix build directory permissions: {e}\nstderr: {e.stderr}"
                 )
-                self._cleanup_kernel_overlay()
+                if self._kernel_overlay_volume:
+                    self._cleanup_kernel_overlay()
                 raise
 
             try:
@@ -630,7 +673,8 @@ class DockerManager:
                 self.logger.error(
                     f"Failed to prepare kernel tree at {self.commit_sha}: {e}\nstderr: {e.stderr}"
                 )
-                self._cleanup_kernel_overlay()
+                if self._kernel_overlay_volume:
+                    self._cleanup_kernel_overlay()
                 raise
 
     def _prepare_kernel_tree(self) -> None:
@@ -645,18 +689,29 @@ class DockerManager:
                 "--user",
                 "root",
                 "--workdir",
-                str(self.kernel_dir),
+                self._container_path(self.kernel_dir),
                 self.container_name,
                 "git",
                 "config",
                 "--global",
                 "--add",
                 "safe.directory",
-                str(self.kernel_dir),
+                self._container_path(self.kernel_dir),
             ],
             check=True,
             capture_output=True,
         )
+
+        # On Windows we bind-mount the host kernel tree directly because the
+        # overlay-volume approach is not reliable under Docker Desktop. Large
+        # git reset/clean sweeps over that bind mount are extremely slow and
+        # can stall fixture setup for a long time, so leave the tree as-is.
+        if self._using_bind_mounted_kernel():
+            self.logger.debug(
+                "Using bind-mounted kernel tree; skipping reset/clean/chown preparation."
+            )
+            return
+
         subprocess.run(
             [
                 "docker",
@@ -664,7 +719,7 @@ class DockerManager:
                 "--user",
                 "root",
                 "--workdir",
-                str(self.kernel_dir),
+                self._container_path(self.kernel_dir),
                 self.container_name,
                 "git",
                 "reset",
@@ -681,7 +736,7 @@ class DockerManager:
                 "--user",
                 "root",
                 "--workdir",
-                str(self.kernel_dir),
+                self._container_path(self.kernel_dir),
                 self.container_name,
                 "git",
                 "clean",
@@ -700,7 +755,7 @@ class DockerManager:
                 "chown",
                 "-R",
                 "patchwise:patchwise",
-                str(self.kernel_dir),
+                self._container_path(self.kernel_dir),
             ],
             check=True,
             capture_output=True,

--- a/patchwise/docker.py
+++ b/patchwise/docker.py
@@ -34,11 +34,6 @@ class DockerManager:
         self.kernel_dir = self.sandbox_path / "kernel"
         self._kernel_overlay_volume: Optional[str] = None
 
-    @staticmethod
-    def _container_path(path: Path | str) -> str:
-        """Normalize a container path to POSIX form for Docker CLI calls."""
-        return str(path).replace("\\", "/")
-
     @property
     def _kernel_volume_name(self) -> str:
         """Docker volume name for this container's kernel overlay."""
@@ -233,9 +228,9 @@ class DockerManager:
                 "--name",
                 self.container_name,
                 "-v",
-                f"{build_path}:{self._container_path(self.build_dir)}",
+                f"{build_path}:{self.build_dir}",
                 "-v",
-                f"{self._kernel_overlay_volume}:{self._container_path(self.kernel_dir)}",
+                f"{self._kernel_overlay_volume}:{self.kernel_dir}",
                 self.image_tag,
                 "tail",
                 "-f",
@@ -271,9 +266,9 @@ class DockerManager:
         self, command: list[str], cwd: Optional[str], **kwargs: Any
     ) -> subprocess.Popen[str]:
         if not cwd:
-            cwd = self._container_path(self.sandbox_path)
+            cwd = str(self.sandbox_path)
         else:
-            cwd = self._container_path(cwd)
+            cwd = str(cwd)
 
         docker_command = ["docker", "exec"]
         docker_command.extend(["--workdir", cwd])
@@ -295,9 +290,9 @@ class DockerManager:
     ) -> subprocess.Popen[str]:
         """Run an interactive command that needs stdin/stdout communication."""
         if not cwd:
-            cwd = self._container_path(self.sandbox_path)
+            cwd = str(self.sandbox_path)
         else:
-            cwd = self._container_path(cwd)
+            cwd = str(cwd)
 
         docker_command = ["docker", "exec", "-i"]
         docker_command.extend(["--workdir", cwd])
@@ -334,8 +329,8 @@ class DockerManager:
 
         # Create index directory in container
         create_proc = self.run_command(
-            ["mkdir", "-p", self._container_path(index_dir)],
-            cwd=self._container_path(self.build_dir),
+            ["mkdir", "-p", str(index_dir)],
+            cwd=str(self.build_dir),
         )
         create_proc.wait()
 
@@ -355,7 +350,7 @@ class DockerManager:
                     "chown",
                     "-R",
                     "patchwise:patchwise",
-                    self._container_path(index_dir),
+                    str(index_dir),
                 ],
                 check=True,
                 capture_output=True,
@@ -371,7 +366,7 @@ class DockerManager:
                     "chmod",
                     "-R",
                     "755",
-                    self._container_path(index_dir),
+                    str(index_dir),
                 ],
                 check=True,
                 capture_output=True,
@@ -390,9 +385,9 @@ class DockerManager:
     ) -> subprocess.Popen[str]:
         """Start clangd via docker exec with direct stdin/stdout communication."""
         if not cwd:
-            cwd = self._container_path(self.kernel_dir)
+            cwd = str(self.kernel_dir)
         else:
-            cwd = self._container_path(cwd)
+            cwd = str(cwd)
 
         # Ensure index directory exists
         self.ensure_clangd_index_dir()
@@ -612,9 +607,9 @@ class DockerManager:
                 "-v",
                 f"{self._build_volume_name}:/shared/build",
                 "-v",
-                f"{self._build_volume_name}:{self._container_path(self.build_dir)}",
+                f"{self._build_volume_name}:{self.build_dir}",
                 "-v",
-                f"{self._kernel_overlay_volume}:{self._container_path(self.kernel_dir)}",
+                f"{self._kernel_overlay_volume}:{self.kernel_dir}",
                 self.image_tag,
                 "tail",
                 "-f",
@@ -668,14 +663,14 @@ class DockerManager:
                 "--user",
                 "root",
                 "--workdir",
-                self._container_path(self.kernel_dir),
+                str(self.kernel_dir),
                 self.container_name,
                 "git",
                 "config",
                 "--global",
                 "--add",
                 "safe.directory",
-                self._container_path(self.kernel_dir),
+                str(self.kernel_dir),
             ],
             check=True,
             capture_output=True,
@@ -688,7 +683,7 @@ class DockerManager:
                 "--user",
                 "root",
                 "--workdir",
-                self._container_path(self.kernel_dir),
+                str(self.kernel_dir),
                 self.container_name,
                 "git",
                 "reset",
@@ -705,7 +700,7 @@ class DockerManager:
                 "--user",
                 "root",
                 "--workdir",
-                self._container_path(self.kernel_dir),
+                str(self.kernel_dir),
                 self.container_name,
                 "git",
                 "clean",
@@ -724,7 +719,7 @@ class DockerManager:
                 "chown",
                 "-R",
                 "patchwise:patchwise",
-                self._container_path(self.kernel_dir),
+                str(self.kernel_dir),
             ],
             check=True,
             capture_output=True,

--- a/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
@@ -133,7 +133,8 @@ Tools (all paths are kernel-relative, e.g. `drivers/mtd/nand/raw/qcom_nandc.c`):
 - `read_file(path, start?, end?)`
 - `list_files(path, recursive?)`
 - `git_log(path)`
-- `git_show(rev)`
+- `git_show(rev, name_only?)`
+- `git_cat_file(rev, path, start?, end?)`
 
 Only write your review once you have verified your findings against the code. Do not speculate — if you cannot confirm a bug by reading the relevant definitions, do not comment on it.
 Tool results include file paths and snippets; use the paths as `file=` hints on follow-up calls to disambiguate symbols that exist in multiple subsystems. Prefer several targeted tool calls over guessing.
@@ -740,6 +741,10 @@ regulator-name.
             raise ValueError(f"Path escapes kernel tree: {rel}")
         return target
 
+    def _container_kernel_path(self, rel: str) -> str:
+        """Return a kernel-relative path anchored at the container kernel root."""
+        return self.docker_manager._container_path(self.docker_manager.kernel_dir / rel)
+
     def _validate_existing_kernel_path(self, path: str) -> str:
         """Validate and normalize a kernel-relative path that must exist."""
         try:
@@ -748,7 +753,7 @@ regulator-name.
             raise ValueError(str(e))
 
         rel = self._kernel_rel(path)
-        container_path = str(self.docker_manager.kernel_dir / rel)
+        container_path = self._container_kernel_path(rel)
         check = self.docker_manager.run_command(["test", "-e", container_path], cwd=None)
         check.communicate()
         if check.returncode != 0:
@@ -780,6 +785,43 @@ regulator-name.
             detail = stderr.strip() or stdout.strip() or rev
             raise ValueError(f"invalid rev: {detail}")
         return stdout.strip()
+
+    def _validate_git_path(self, path: str) -> str:
+        """Validate a kernel-relative path for git object access."""
+        try:
+            self._abs_in_kernel(path)
+        except ValueError as e:
+            raise ValueError(str(e))
+        return self._kernel_rel(path)
+
+    def _split_git_object_spec(self, rev: str) -> Tuple[str, Optional[str]]:
+        """Split `rev[:path]` syntax into commit rev and optional kernel-relative path."""
+        if not isinstance(rev, str) or not rev.strip():
+            raise ValueError("rev must be a non-empty string")
+        if rev.startswith("-"):
+            raise ValueError(f"invalid rev: {rev}")
+        if any(c in rev for c in ("\x00", "\n", "\r")):
+            raise ValueError(f"invalid rev: {rev}")
+
+        if ":" not in rev:
+            return rev, None
+
+        commit_rev, rel_path = rev.split(":", 1)
+        if not commit_rev or not rel_path:
+            raise ValueError(f"invalid rev: {rev}")
+        return commit_rev, self._validate_git_path(rel_path)
+
+    def _resolve_git_object_spec(self, rev: str) -> Tuple[str, Optional[str], str]:
+        """Resolve a git commit or commit:path object spec."""
+        commit_rev, rel_path = self._split_git_object_spec(rev)
+        resolved_rev = self._resolve_git_commit(commit_rev)
+        if rel_path is None:
+            return resolved_rev, None, resolved_rev
+        return resolved_rev, rel_path, f"{resolved_rev}:{rel_path}"
+
+    def _git_command(self, *args: str) -> List[str]:
+        """Run git with paging disabled so tool output is deterministic."""
+        return ["git", "--no-pager", *args]
 
     def _snippet_for_range(
         self, rel_path: str, start_line: int, end_line: int, ctx: int = 2
@@ -848,6 +890,16 @@ regulator-name.
         if not line:
             raise RuntimeError("ts_indexer daemon closed stdout")
         return json.loads(line)
+
+    def _ensure_navigation_stack(
+        self, need_lsp: bool = False, need_ts: bool = False
+    ) -> None:
+        """Lazily start expensive code-navigation services on first use."""
+        if need_lsp and getattr(self, "agent_lsp_proc", None) is None:
+            self.generate_compile_commands()
+            self.agent_lsp_proc = self._setup_lsp_client()
+        if need_ts and getattr(self, "ts_daemon", None) is None:
+            self._start_ts_daemon()
 
     def _ts_lookup(self, name: str, limit: int = 100) -> List[Dict[str, Any]]:
         """Return up to `limit` index entries matching `name`."""
@@ -1037,6 +1089,7 @@ regulator-name.
     def _tool_find_definition(
         self, name: str, file: Optional[str] = None
     ) -> Dict[str, Any]:
+        self._ensure_navigation_stack(need_lsp=True, need_ts=True)
         active_def = self._find_active_definition(name, file)
         if active_def is None:
             return {"ok": False, "error": f"symbol '{name}' not found in index"}
@@ -1102,6 +1155,7 @@ regulator-name.
     def _tool_find_callers(
         self, name: str, file: Optional[str] = None
     ) -> Dict[str, Any]:
+        self._ensure_navigation_stack(need_lsp=True, need_ts=True)
         active_def = self._find_active_definition(name, file)
         if active_def is None:
             return {"ok": False, "error": f"symbol '{name}' not found in index"}
@@ -1148,6 +1202,7 @@ regulator-name.
         file: Optional[str] = None,
         glob: Optional[str] = None,
     ) -> Dict[str, Any]:
+        self._ensure_navigation_stack(need_ts=True)
         try:
             re.compile(pattern)
         except re.error as e:
@@ -1340,8 +1395,7 @@ regulator-name.
 
         kernel_dir = str(self.docker_manager.kernel_dir)
         log_cmd = [
-            "git",
-            "log",
+            *self._git_command("log"),
             "--no-ext-diff",
             "--no-textconv",
             "--no-color",
@@ -1373,7 +1427,7 @@ regulator-name.
             )
 
         count_proc = self.docker_manager.run_command(
-            ["git", "rev-list", "--count", "HEAD", "--", rel],
+            self._git_command("rev-list", "--count", "HEAD", "--", rel),
             cwd=kernel_dir,
         )
         count_stdout, count_stderr = count_proc.communicate()
@@ -1393,29 +1447,57 @@ regulator-name.
             "truncated": truncated,
         }
 
-    def _tool_git_show(self, rev: str) -> Dict[str, Any]:
+    def _tool_git_show(self, rev: str, name_only: bool = False) -> Dict[str, Any]:
         try:
-            resolved_rev = self._resolve_git_commit(rev)
+            resolved_rev, rel_path, object_spec = self._resolve_git_object_spec(rev)
         except ValueError as e:
             return {"ok": False, "error": str(e)}
 
+        if name_only and rel_path is not None:
+            return {
+                "ok": False,
+                "error": "name_only is only supported for commit revisions, not rev:path",
+            }
+
         kernel_dir = str(self.docker_manager.kernel_dir)
-        show_cmd = [
-            "git",
-            "show",
-            "--no-ext-diff",
-            "--no-textconv",
-            "--no-color",
-            "--stat=80,20",
-            "--format=medium",
-            "--unified=3",
-            resolved_rev,
-        ]
+        if name_only:
+            show_cmd = [
+                *self._git_command("show"),
+                "--format=",
+                "--name-only",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-color",
+                resolved_rev,
+            ]
+        else:
+            show_cmd = [
+                *self._git_command("show"),
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-color",
+                "--stat=80,20",
+                "--format=medium",
+                "--unified=3",
+                object_spec,
+            ]
         proc = self.docker_manager.run_command(show_cmd, cwd=kernel_dir)
         stdout, stderr = proc.communicate()
         if proc.returncode != 0:
             detail = stderr.strip() or "git show failed"
             return {"ok": False, "error": detail}
+
+        if name_only:
+            paths = [line.strip() for line in stdout.splitlines() if line.strip()]
+            total = len(paths)
+            return {
+                "ok": True,
+                "result": {
+                    "rev": resolved_rev,
+                    "paths": paths[:200],
+                    "truncated": total > 200,
+                },
+            }
 
         lines = stdout.splitlines(keepends=True)
         total_lines = len(lines)
@@ -1423,9 +1505,48 @@ regulator-name.
         return {
             "ok": True,
             "result": {
-                "rev": resolved_rev,
+                "rev": object_spec,
                 "content": "".join(lines[:end]),
                 "truncated": total_lines > 200,
+            },
+        }
+
+    def _tool_git_cat_file(
+        self, rev: str, path: str, start: int = 1, end: Optional[int] = None
+    ) -> Dict[str, Any]:
+        try:
+            resolved_rev = self._resolve_git_commit(rev)
+            rel = self._validate_git_path(path)
+        except ValueError as e:
+            return {"ok": False, "error": str(e)}
+
+        kernel_dir = str(self.docker_manager.kernel_dir)
+        object_spec = f"{resolved_rev}:{rel}"
+        proc = self.docker_manager.run_command(
+            self._git_command("cat-file", "-p", object_spec),
+            cwd=kernel_dir,
+        )
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            detail = stderr.strip() or "git cat-file failed"
+            if not detail.startswith("git cat-file failed"):
+                detail = f"git cat-file failed: {detail}"
+            return {"ok": False, "error": detail}
+
+        lines = stdout.splitlines(keepends=True)
+        total_lines = len(lines)
+        start_1 = max(1, start)
+        request_end = end if end is not None else start_1 + 199
+        effective_end = min(request_end, start_1 + 199, total_lines)
+        return {
+            "ok": True,
+            "result": {
+                "rev": resolved_rev,
+                "path": rel,
+                "start": start_1,
+                "end": effective_end,
+                "content": "".join(lines[start_1 - 1 : effective_end]),
+                "truncated": effective_end < total_lines,
             },
         }
 
@@ -1440,6 +1561,7 @@ regulator-name.
             "list_files": self._tool_list_files,
             "git_log": self._tool_git_log,
             "git_show": self._tool_git_show,
+            "git_cat_file": self._tool_git_cat_file,
         }
         tool_fn = tool_map.get(name)
         if tool_fn is None:
@@ -1622,10 +1744,6 @@ regulator-name.
         self.seen_files: Set[str] = set()
 
         self.seen_files |= self._files_in_diff()
-
-        self.generate_compile_commands()
-        self.agent_lsp_proc = self._setup_lsp_client()
-        self._start_ts_daemon()
 
     def run(self) -> str:
         """Execute the AI code review."""

--- a/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
@@ -132,6 +132,8 @@ Tools (all paths are kernel-relative, e.g. `drivers/mtd/nand/raw/qcom_nandc.c`):
 - `grep(pattern, file?)`
 - `read_file(path, start?, end?)`
 - `list_files(path, recursive?)`
+- `git_log(path)`
+- `git_show(rev)`
 
 Only write your review once you have verified your findings against the code. Do not speculate — if you cannot confirm a bug by reading the relevant definitions, do not comment on it.
 Tool results include file paths and snippets; use the paths as `file=` hints on follow-up calls to disambiguate symbols that exist in multiple subsystems. Prefer several targeted tool calls over guessing.
@@ -738,6 +740,47 @@ regulator-name.
             raise ValueError(f"Path escapes kernel tree: {rel}")
         return target
 
+    def _validate_existing_kernel_path(self, path: str) -> str:
+        """Validate and normalize a kernel-relative path that must exist."""
+        try:
+            self._abs_in_kernel(path)
+        except ValueError as e:
+            raise ValueError(str(e))
+
+        rel = self._kernel_rel(path)
+        container_path = str(self.docker_manager.kernel_dir / rel)
+        check = self.docker_manager.run_command(["test", "-e", container_path], cwd=None)
+        check.communicate()
+        if check.returncode != 0:
+            raise ValueError(f"path not found: {rel}")
+        return rel
+
+    def _resolve_git_commit(self, rev: str) -> str:
+        """Resolve a revision to a commit SHA, rejecting invalid or option-like refs."""
+        if not isinstance(rev, str) or not rev.strip():
+            raise ValueError("rev must be a non-empty string")
+        if rev.startswith("-"):
+            raise ValueError(f"invalid rev: {rev}")
+        if any(c in rev for c in ("\x00", "\n", "\r")):
+            raise ValueError(f"invalid rev: {rev}")
+
+        kernel_dir = str(self.docker_manager.kernel_dir)
+        proc = self.docker_manager.run_command(
+            [
+                "git",
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                f"{rev}^{{commit}}",
+            ],
+            cwd=kernel_dir,
+        )
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            detail = stderr.strip() or stdout.strip() or rev
+            raise ValueError(f"invalid rev: {detail}")
+        return stdout.strip()
+
     def _snippet_for_range(
         self, rel_path: str, start_line: int, end_line: int, ctx: int = 2
     ) -> str:
@@ -1289,6 +1332,103 @@ regulator-name.
             },
         }
 
+    def _tool_git_log(self, path: str) -> Dict[str, Any]:
+        try:
+            rel = self._validate_existing_kernel_path(path)
+        except ValueError as e:
+            return {"ok": False, "error": str(e)}
+
+        kernel_dir = str(self.docker_manager.kernel_dir)
+        log_cmd = [
+            "git",
+            "log",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--max-count",
+            "101",
+            "--format=%H%x1f%an%x1f%ad%x1f%s",
+            "--date=short",
+            "--",
+            rel,
+        ]
+        proc = self.docker_manager.run_command(log_cmd, cwd=kernel_dir)
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            detail = stderr.strip() or "git log failed"
+            return {"ok": False, "error": detail}
+
+        commits: List[Dict[str, str]] = []
+        for line in stdout.splitlines():
+            parts = line.split("\x1f")
+            if len(parts) != 4:
+                continue
+            commits.append(
+                {
+                    "rev": parts[0],
+                    "author": parts[1],
+                    "date": parts[2],
+                    "subject": parts[3],
+                }
+            )
+
+        count_proc = self.docker_manager.run_command(
+            ["git", "rev-list", "--count", "HEAD", "--", rel],
+            cwd=kernel_dir,
+        )
+        count_stdout, count_stderr = count_proc.communicate()
+        if count_proc.returncode != 0:
+            detail = count_stderr.strip() or "git rev-list failed"
+            return {"ok": False, "error": detail}
+
+        try:
+            total = int(count_stdout.strip())
+        except ValueError:
+            total = len(commits)
+        truncated = total > 100
+        return {
+            "ok": True,
+            "result": commits[:100],
+            "total": total,
+            "truncated": truncated,
+        }
+
+    def _tool_git_show(self, rev: str) -> Dict[str, Any]:
+        try:
+            resolved_rev = self._resolve_git_commit(rev)
+        except ValueError as e:
+            return {"ok": False, "error": str(e)}
+
+        kernel_dir = str(self.docker_manager.kernel_dir)
+        show_cmd = [
+            "git",
+            "show",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--stat=80,20",
+            "--format=medium",
+            "--unified=3",
+            resolved_rev,
+        ]
+        proc = self.docker_manager.run_command(show_cmd, cwd=kernel_dir)
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            detail = stderr.strip() or "git show failed"
+            return {"ok": False, "error": detail}
+
+        lines = stdout.splitlines(keepends=True)
+        total_lines = len(lines)
+        end = min(total_lines, 200)
+        return {
+            "ok": True,
+            "result": {
+                "rev": resolved_rev,
+                "content": "".join(lines[:end]),
+                "truncated": total_lines > 200,
+            },
+        }
+
     def dispatch_tool(self, name: str, args: dict) -> dict:
         """Dispatch an agent tool by name. Returns {ok, ...}."""
         tool_map = {
@@ -1298,6 +1438,8 @@ regulator-name.
             "grep": self._tool_grep,
             "read_file": self._tool_read_file,
             "list_files": self._tool_list_files,
+            "git_log": self._tool_git_log,
+            "git_show": self._tool_git_show,
         }
         tool_fn = tool_map.get(name)
         if tool_fn is None:

--- a/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
@@ -743,14 +743,11 @@ regulator-name.
 
     def _container_kernel_path(self, rel: str) -> str:
         """Return a kernel-relative path anchored at the container kernel root."""
-        return self.docker_manager._container_path(self.docker_manager.kernel_dir / rel)
+        return str(self.docker_manager.kernel_dir / rel)
 
     def _validate_existing_kernel_path(self, path: str) -> str:
         """Validate and normalize a kernel-relative path that must exist."""
-        try:
-            self._abs_in_kernel(path)
-        except ValueError as e:
-            raise ValueError(str(e))
+        self._abs_in_kernel(path)
 
         rel = self._kernel_rel(path)
         container_path = self._container_kernel_path(rel)
@@ -788,10 +785,7 @@ regulator-name.
 
     def _validate_git_path(self, path: str) -> str:
         """Validate a kernel-relative path for git object access."""
-        try:
-            self._abs_in_kernel(path)
-        except ValueError as e:
-            raise ValueError(str(e))
+        self._abs_in_kernel(path)
         return self._kernel_rel(path)
 
     def _split_git_object_spec(self, rev: str) -> Tuple[str, Optional[str]]:
@@ -1426,19 +1420,7 @@ regulator-name.
                 }
             )
 
-        count_proc = self.docker_manager.run_command(
-            self._git_command("rev-list", "--count", "HEAD", "--", rel),
-            cwd=kernel_dir,
-        )
-        count_stdout, count_stderr = count_proc.communicate()
-        if count_proc.returncode != 0:
-            detail = count_stderr.strip() or "git rev-list failed"
-            return {"ok": False, "error": detail}
-
-        try:
-            total = int(count_stdout.strip())
-        except ValueError:
-            total = len(commits)
+        total = len(commits)
         truncated = total > 100
         return {
             "ok": True,

--- a/patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py
@@ -5,7 +5,8 @@
 All tools accept and return kernel-relative paths (e.g. 'drivers/usb/foo.c').
 The `file` arg on name-taking tools is a hint for where you saw the symbol
 used, not where its definition lives. The tool resolves the definition
-itself. List tools cap results at 100; read_file/git_show cap at 200 lines.
+itself. List tools cap results at 100; read_file/git_show/git_cat_file cap at
+200 lines.
 """
 
 _NAME_PARAM = {
@@ -195,8 +196,12 @@ TOOLS = [
         "function": {
             "name": "git_show",
             "description": (
-                "Show a commit object by revision. Returns {rev, content, "
-                "truncated}. Capped at 200 lines per call."
+                "Show a commit or historical file object by revision. `rev` may "
+                "be a commit id/revision (e.g. HEAD~1) or `<commit-id>:<relative/path>` "
+                "(e.g. `43cfbdda5af6:drivers/remoteproc/qcom_q6v5.c`). Set "
+                "`name_only=true` to return only changed file paths for a commit. "
+                "Returns {rev, content, truncated} or {rev, paths, truncated}. "
+                "Capped at 200 lines or 200 paths per call."
             ),
             "parameters": {
                 "type": "object",
@@ -204,11 +209,53 @@ TOOLS = [
                     "rev": {
                         "type": "string",
                         "description": (
-                            "A commit revision such as HEAD, HEAD~1, or a commit SHA."
+                            "A commit revision such as HEAD, HEAD~1, or a commit SHA, "
+                            "or a historical file object like "
+                            "'43cfbdda5af6:drivers/remoteproc/qcom_q6v5.c'."
+                        ),
+                    },
+                    "name_only": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, return only the changed file paths for the commit."
                         ),
                     },
                 },
                 "required": ["rev"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "git_cat_file",
+            "description": (
+                "Read a historical file from git by commit revision and kernel-relative "
+                "path. Returns {rev, path, start, end, content, truncated}. "
+                "Capped at 200 lines per call. Use this when `git_show` output is "
+                "truncated or when you want file contents without a patch."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "rev": {
+                        "type": "string",
+                        "description": "A commit revision such as HEAD, HEAD~1, or a commit SHA.",
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Kernel-relative path inside that revision.",
+                    },
+                    "start": {
+                        "type": "integer",
+                        "description": "1-based starting line (default 1).",
+                    },
+                    "end": {
+                        "type": "integer",
+                        "description": "1-based ending line, inclusive (default start+199).",
+                    },
+                },
+                "required": ["rev", "path"],
             },
         },
     },

--- a/patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py
@@ -5,7 +5,7 @@
 All tools accept and return kernel-relative paths (e.g. 'drivers/usb/foo.c').
 The `file` arg on name-taking tools is a hint for where you saw the symbol
 used, not where its definition lives. The tool resolves the definition
-itself. List tools cap results at 100; read_file caps at 200 lines.
+itself. List tools cap results at 100; read_file/git_show cap at 200 lines.
 """
 
 _NAME_PARAM = {
@@ -163,6 +163,52 @@ TOOLS = [
                     },
                 },
                 "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "git_log",
+            "description": (
+                "Show recent commit history touching a kernel-relative file or "
+                "directory path. Returns {result: [{rev, author, date, subject}], "
+                "total, truncated}. Capped at 100 commits."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": (
+                            "Kernel-relative file or directory path whose history "
+                            "you want to inspect."
+                        ),
+                    },
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "git_show",
+            "description": (
+                "Show a commit object by revision. Returns {rev, content, "
+                "truncated}. Capped at 200 lines per call."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "rev": {
+                        "type": "string",
+                        "description": (
+                            "A commit revision such as HEAD, HEAD~1, or a commit SHA."
+                        ),
+                    },
+                },
+                "required": ["rev"],
             },
         },
     },

--- a/tests/ai_code_review/test_tools.py
+++ b/tests/ai_code_review/test_tools.py
@@ -8,6 +8,7 @@ a pinned linux-next checkout cloned into tests/linux/, then exercises each
 tool exposed via AiCodeReview.dispatch_tool:
 
   find_definition / find_callers / find_calls / grep / read_file / list_files
+  / git_log / git_show
 
 Run with the patchwise venv active.
 
@@ -382,5 +383,78 @@ def test_list_files_errors(
     review: AiCodeReview, path: str, expected_error: str
 ) -> None:
     result = review.dispatch_tool("list_files", {"path": path})
+    assert not result.get("ok"), f"unexpectedly ok: {result}"
+    assert expected_error in (result.get("error") or "")
+
+
+# ---------------------------------------------------------------------------
+# git_log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,min_count",
+    [
+        ("fs/open.c", 1),
+        ("include/linux/list.h", 1),
+    ],
+    ids=lambda v: str(v),
+)
+def test_git_log(review: AiCodeReview, path: str, min_count: int) -> None:
+    result = review.dispatch_tool("git_log", {"path": path})
+    assert result.get("ok"), f"tool returned not-ok: {result}"
+    commits = result.get("result", [])
+    total = result.get("total", 0)
+    assert total >= min_count, f"only {total} commits (wanted >= {min_count})"
+    assert commits, "expected at least one commit entry"
+    first = commits[0]
+    assert first.get("rev"), f"missing rev in {first}"
+    assert first.get("author"), f"missing author in {first}"
+    assert first.get("date"), f"missing date in {first}"
+    assert first.get("subject"), f"missing subject in {first}"
+
+
+@pytest.mark.parametrize(
+    "path,expected_error",
+    [
+        ("../../../etc/passwd", "escapes kernel tree"),
+        ("does/not/exist", "path not found"),
+    ],
+    ids=["path_escape", "missing_path"],
+)
+def test_git_log_errors(
+    review: AiCodeReview, path: str, expected_error: str
+) -> None:
+    result = review.dispatch_tool("git_log", {"path": path})
+    assert not result.get("ok"), f"unexpectedly ok: {result}"
+    assert expected_error in (result.get("error") or "")
+
+
+# ---------------------------------------------------------------------------
+# git_show
+# ---------------------------------------------------------------------------
+
+
+def test_git_show(review: AiCodeReview) -> None:
+    result = review.dispatch_tool("git_show", {"rev": PINNED_COMMIT})
+    assert result.get("ok"), f"tool returned not-ok: {result}"
+    payload = result.get("result", {})
+    assert payload.get("rev") == PINNED_COMMIT
+    content = payload.get("content", "")
+    assert f"commit {PINNED_COMMIT}" in content
+
+
+@pytest.mark.parametrize(
+    "rev,expected_error",
+    [
+        ("not_a_real_rev", "invalid rev"),
+        ("-n1", "invalid rev"),
+    ],
+    ids=["missing_rev", "option_like_rev"],
+)
+def test_git_show_errors(
+    review: AiCodeReview, rev: str, expected_error: str
+) -> None:
+    result = review.dispatch_tool("git_show", {"rev": rev})
     assert not result.get("ok"), f"unexpectedly ok: {result}"
     assert expected_error in (result.get("error") or "")

--- a/tests/ai_code_review/test_tools.py
+++ b/tests/ai_code_review/test_tools.py
@@ -8,7 +8,7 @@ a pinned linux-next checkout cloned into tests/linux/, then exercises each
 tool exposed via AiCodeReview.dispatch_tool:
 
   find_definition / find_callers / find_calls / grep / read_file / list_files
-  / git_log / git_show
+  / git_log / git_show / git_cat_file
 
 Run with the patchwise venv active.
 
@@ -20,6 +20,7 @@ The first run is slow: init_kernel_tree() fetches linux-next.
 
 import logging
 import os
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -29,6 +30,7 @@ KERNEL_DIR = TESTS_DIR / "linux"
 os.environ["PATCHWISE_SANDBOX_PATH"] = str(TESTS_DIR)
 
 import pytest
+from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 
 from patchwise.patch_review.ai_review.ai_code_review.ai_code_review import AiCodeReview
 from patchwise.patch_review.kernel_tree import init_kernel_tree
@@ -38,6 +40,39 @@ from patchwise.patch_review.kernel_tree import init_kernel_tree
 PINNED_COMMIT = "43cfbdda5af60ffc6272a7b8c5c37d1d0a181ca9"
 
 
+def _clear_stale_index_lock(repo_path: Path) -> None:
+    """Remove a leftover git index lock from a previously interrupted run."""
+    lock_path = repo_path / ".git" / "index.lock"
+    if lock_path.exists():
+        lock_path.unlink()
+
+
+def _checkout_pinned_commit(repo: Any) -> None:
+    """Checkout the pinned commit with light recovery for stale lock files."""
+    if repo.head.is_valid() and repo.head.commit.hexsha == PINNED_COMMIT:
+        return
+
+    for attempt in range(2):
+        try:
+            repo.git.checkout(PINNED_COMMIT)
+            return
+        except Exception as exc:
+            if attempt == 1 or "index.lock" not in str(exc):
+                raise
+            _clear_stale_index_lock(Path(repo.working_tree_dir))
+            time.sleep(1)
+
+    raise RuntimeError(f"failed to checkout pinned commit {PINNED_COMMIT}")
+
+
+def _open_or_init_kernel_repo(repo_path: Path) -> Repo:
+    """Reuse an existing local kernel repo when present; fetch only on first setup."""
+    try:
+        return Repo(repo_path)
+    except (InvalidGitRepositoryError, NoSuchPathError):
+        return init_kernel_tree(repo_path)
+
+
 @pytest.fixture(scope="session")
 def review() -> AiCodeReview:
     logging.basicConfig(
@@ -45,8 +80,9 @@ def review() -> AiCodeReview:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
     print("\n=== Setting up AiCodeReview... ===", flush=True)
-    repo = init_kernel_tree(KERNEL_DIR)
-    repo.git.checkout(PINNED_COMMIT)
+    repo = _open_or_init_kernel_repo(KERNEL_DIR)
+    _clear_stale_index_lock(KERNEL_DIR)
+    _checkout_pinned_commit(repo)
     head = repo.head.commit
     print(
         f"Using kernel={KERNEL_DIR} head={head.hexsha[:12]} ({head.summary!r})",
@@ -444,17 +480,70 @@ def test_git_show(review: AiCodeReview) -> None:
     assert f"commit {PINNED_COMMIT}" in content
 
 
+def test_git_show_name_only(review: AiCodeReview) -> None:
+    result = review.dispatch_tool("git_show", {"rev": PINNED_COMMIT, "name_only": True})
+    assert result.get("ok"), f"tool returned not-ok: {result}"
+    payload = result.get("result", {})
+    assert payload.get("rev") == PINNED_COMMIT
+    paths = payload.get("paths", [])
+    assert paths, "expected changed file paths"
+
+
+def test_git_show_object_path(review: AiCodeReview) -> None:
+    rev = f"{PINNED_COMMIT}:fs/open.c"
+    result = review.dispatch_tool("git_show", {"rev": rev})
+    assert result.get("ok"), f"tool returned not-ok: {result}"
+    payload = result.get("result", {})
+    assert payload.get("rev") == rev
+    content = payload.get("content", "")
+    assert "diff --git" not in content
+
+
 @pytest.mark.parametrize(
-    "rev,expected_error",
+    "args,expected_error",
     [
-        ("not_a_real_rev", "invalid rev"),
-        ("-n1", "invalid rev"),
+        ({"rev": "not_a_real_rev"}, "invalid rev"),
+        ({"rev": "-n1"}, "invalid rev"),
+        ({"rev": f"{PINNED_COMMIT}:fs/open.c", "name_only": True}, "name_only"),
     ],
-    ids=["missing_rev", "option_like_rev"],
+    ids=["missing_rev", "option_like_rev", "name_only_with_object_spec"],
 )
 def test_git_show_errors(
-    review: AiCodeReview, rev: str, expected_error: str
+    review: AiCodeReview, args: Dict[str, Any], expected_error: str
 ) -> None:
-    result = review.dispatch_tool("git_show", {"rev": rev})
+    result = review.dispatch_tool("git_show", args)
+    assert not result.get("ok"), f"unexpectedly ok: {result}"
+    assert expected_error in (result.get("error") or "")
+
+
+# ---------------------------------------------------------------------------
+# git_cat_file
+# ---------------------------------------------------------------------------
+
+
+def test_git_cat_file(review: AiCodeReview) -> None:
+    result = review.dispatch_tool(
+        "git_cat_file", {"rev": PINNED_COMMIT, "path": "fs/open.c", "start": 1, "end": 20}
+    )
+    assert result.get("ok"), f"tool returned not-ok: {result}"
+    payload = result.get("result", {})
+    assert payload.get("rev") == PINNED_COMMIT
+    assert payload.get("path") == "fs/open.c"
+    assert "Copyright" in payload.get("content", "")
+
+
+@pytest.mark.parametrize(
+    "args,expected_error",
+    [
+        ({"rev": "not_a_real_rev", "path": "fs/open.c"}, "invalid rev"),
+        ({"rev": PINNED_COMMIT, "path": "../../../etc/passwd"}, "escapes kernel tree"),
+        ({"rev": PINNED_COMMIT, "path": "does/not/exist.c"}, "git cat-file failed"),
+    ],
+    ids=["missing_rev", "path_escape", "missing_path_in_commit"],
+)
+def test_git_cat_file_errors(
+    review: AiCodeReview, args: Dict[str, Any], expected_error: str
+) -> None:
+    result = review.dispatch_tool("git_cat_file", args)
     assert not result.get("ok"), f"unexpectedly ok: {result}"
     assert expected_error in (result.get("error") or "")


### PR DESCRIPTION
Addressed review feedback:
- added --no-pager for git tool invocations
- extended git_show to support <commit>:<path>
- added name_only support to git_show
- added git_cat_file(rev, path, start?, end?)
- updated tool docs and tests

Validation:
- pytest tests/ai_code_review/test_tools.py -k "git_log or git_show or git_cat_file" -v -s
- all selected tests passed locally on Windows after fixing fixture/container setup issues
