### PR TITLE
coccicheck: add OCaml compiler install to dockerfile

### DIFF
--- a/patchwise/dockerfiles/Coccicheck.Dockerfile
+++ b/patchwise/dockerfiles/Coccicheck.Dockerfile
@@ -4,8 +4,10 @@ FROM patchwise-base:latest
 USER root
 
 # Install coccinelle
+# Install OCaml native compiler (it is used for some semantic patches)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     coccinelle \
+    ocaml-native-compilers \
     && rm -rf /var/lib/apt/lists/*
 
 USER patchwise


### PR DESCRIPTION
closes #74

Coccicheck can fail without the Ocaml native compiler tools available.

Verification:
ran: patchwise --repo-path path/to/kernel --reviews Coccicheck --log-level DEBUG

I observed no Coccicheck failures anymore:

```
22:30:08 I patchwise.dockermanager docker.py#201: Tool-specific image patchwise-coccicheck built successfully.
patchwise-kernel-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16
patchwise-kernel-backing-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16
22:30:08 I patchwise.dockermanager docker.py#70: Creating kernel overlay backing volume 'patchwise-kernel-backing-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16' for patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16...
22:30:08 I patchwise.dockermanager docker.py#119: Creating kernel overlay volume 'patchwise-kernel-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16' for patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16...
22:30:08 I patchwise.dockermanager docker.py#140: Kernel overlay volume 'patchwise-kernel-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16' created.
22:30:08 I patchwise.dockermanager docker.py#600: Starting container patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 with shared volume...
22:30:09 I patchwise.dockermanager docker.py#615: Container patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 started successfully.
22:30:09 D patchwise.dockermanager docker.py#766: Fixed permissions for build directory: 7080e32d3f09d8688c4a87d81bdcc71f7f606b16
22:30:09 D patchwise.dockermanager docker.py#638: Preparing kernel tree at 7080e32d3f09d8688c4a87d81bdcc71f7f606b16 in patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16...
22:30:15 D patchwise.dockermanager docker.py#708: Kernel tree at 7080e32d3f09d8688c4a87d81bdcc71f7f606b16 prepared.
22:30:15 D patchwise.patch_review __init__.py#142: Running review: Coccicheck
22:30:15 D patchwise.coccicheck coccicheck.py#84: Running cocci_check
22:30:15 D patchwise.coccicheck coccicheck.py#20: Preparing kernel build system for coccicheck
22:30:15 D patchwise.coccicheck static_analysis.py#41: Making defconfig
22:30:15 D patchwise.dockermanager docker.py#273: Executing command in container: docker exec --workdir /home/patchwise/build patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 make -C /home/patchwise/kernel O=/home/patchwise/build -j12 -s ARCH=arm64 LLVM=1 defconfig
22:30:19 D patchwise.coccicheck patch_review.py#127: defconfig... 4s elapsed
22:30:19 D patchwise.coccicheck coccicheck.py#26: Kernel configuration prepared successfully
22:30:19 D patchwise.dockermanager docker.py#273: Executing command in container: docker exec --workdir /home/patchwise/build patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 make -C /home/patchwise/kernel O=/home/patchwise/build ARCH=arm64 LLVM=1 scripts
22:30:20 D patchwise.coccicheck patch_review.py#117: make: Entering directory '/home/patchwise/kernel'
make[1]: Entering directory '/home/patchwise/build'
make[1]: Leaving directory '/home/patchwise/build'
make: Leaving directory '/home/patchwise/kernel'

22:30:20 D patchwise.coccicheck patch_review.py#127: preparing kernel scripts... 0s elapsed
22:30:20 D patchwise.coccicheck coccicheck.py#45: Kernel scripts prepared successfully
22:30:20 D patchwise.coccicheck coccicheck.py#98: Directories containing modified files: {'Next'}
22:30:20 D patchwise.coccicheck coccicheck.py#101: Running coccicheck on directory: 'Next'
22:30:20 D patchwise.dockermanager docker.py#273: Executing command in container: docker exec --workdir /home/patchwise/build patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 make -C /home/patchwise/kernel O=/home/patchwise/build -j12 ARCH=arm64 LLVM=1 -s coccicheck M=Next MODE=report DEBUG_FILE=/tmp/patchwise.patch_review.static_analysis_null
coccicheck running... 5s elapsed22:30:29 D patchwise.coccicheck patch_review.py#117:
Please check for false positives in the output before submitting a patch.
When using "patch" mode, carefully review the patch before submitting it.

warning: Skipping /home/patchwise/kernel/scripts/coccinelle/api/kmalloc_objs.cocci as it does not match mode 'report'

22:30:29 D patchwise.coccicheck patch_review.py#127: coccicheck running... 8s elapsed
22:30:29 D patchwise.coccicheck coccicheck.py#107: Coccicheck output for Next:

Please check for false positives in the output before submitting a patch.
When using "patch" mode, carefully review the patch before submitting it.

warning: Skipping /home/patchwise/kernel/scripts/coccinelle/api/kmalloc_objs.cocci as it does not match mode 'report'

22:30:29 I patchwise.patch_review __init__.py#147: Coccicheck found no issues
22:30:29 I patchwise.dockermanager docker.py#445: Stopping container patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16...
22:30:39 I patchwise.dockermanager docker.py#457: Container patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 stopped and removed.
patchwise-kernel-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16
patchwise-kernel-backing-patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16
22:30:40 I patchwise.dockermanager docker.py#147: Kernel overlay for patchwise-coccicheck-7080e32d3f09d8688c4a87d81bdcc71f7f606b16 cleaned up.
22:30:40 I patchwise.main main.py#122: Saved Coccicheck results to /tmp/patchwise/output/7080e32d3f09d8688c4a87d81bdcc71f7f606b16/coccicheck.txt
```