### PR TITLE
add patchwise test to GitHub actions #27

### DIFF
--- a/.github/workflows/Readme.md
+++ b/.github/workflows/Readme.md
@@ -4,3 +4,4 @@ This folder contains workflows that are helpful for maintaining a smooth and sec
 Workflows:
 1. `qcom-preflight-checks.yml` - This workflow runs several preflight checks, including copyight, email, repolinter, and security checks.  See [qualcomm/qcom-actions](https://github.com/qualcomm/qcom-actions)
 2. `stale-issues.yaml` - This workflow will periodically run every 30 days to check for stalled issues and PRs. If the workflow detects any stalled issues and/or PRs, it will automatically leave just a comment to draw attention.
+3. `patchwise-regression-checks.yml` - This workflow installs PatchWise from the current checkout and runs `patchwise --help` to check for CLI entry point regressions.

--- a/.github/workflows/patchwise-regression-checks.yml
+++ b/.github/workflows/patchwise-regression-checks.yml
@@ -1,0 +1,36 @@
+name: PatchWise Regression Checks
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  cli-help:
+    name: CLI help
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install PatchWise from this checkout
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Bypass curses TUI
+        run: |
+          mkdir -p "$HOME/.config"
+          cat <<'EOF' > "$HOME/.config/patchwise_config.yaml"
+          api_key_disclaimer:
+            no_reprompt: true
+          EOF
+
+      - name: Run PatchWise help
+        run: patchwise --help

--- a/.github/workflows/patchwise-regression-checks.yml
+++ b/.github/workflows/patchwise-regression-checks.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
 
       - name: Install PatchWise from this checkout
         run: |


### PR DESCRIPTION
## Summary

Add a PatchWise regression checks workflow that: 
- installs the current checkout
- disables the interactive API prompt through PatchWise user config
- runs `patchwise --help`

refs #27 
