### PR TITLE
static_analysis: report only dt-checker errors introduced by the commit

### DIFF
--- a/patchwise/patch_review/static_analysis/dt_check.py
+++ b/patchwise/patch_review/static_analysis/dt_check.py
@@ -65,11 +65,18 @@ class DtCheck(StaticAnalysis):
         )
         return output.strip()
 
-    def __get_dt_checker_logs(self, commit: Optional[Commit] = None) -> tuple[str, str]:
+    def __get_dt_checker_logs(
+        self, commit: Optional[Commit] = None
+    ) -> tuple[Path, Path]:
         # TODO Extract yamllint warnings/errors
         """
         Retrieves and caches dt_checker logs for a given kernel tree and SHA.
-        Logs are saved to files in the 'dt-checker-logs' folder.
+        Logs are saved to files in the 'dt-checker-logs' folder. If both logs
+        are already cached for `commit`, the cached paths are returned without
+        rebuilding. Otherwise the kernel tree is reset to `commit` and the
+        checks are run.
+        
+        Returns (refcheckdocs_log_path, dt_binding_check_log_path).
         """
         logs_dir = Path(SANDBOX_PATH) / "dt-checker-logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
@@ -80,15 +87,31 @@ class DtCheck(StaticAnalysis):
         refcheckdocs_log_path = logs_dir / f"{commit.hexsha}_refcheckdocs.log"
         dt_binding_check_log_path = logs_dir / f"{commit.hexsha}_dt_binding_check.log"
 
-        self.logger.debug(f"Running dt-checker on: {commit.hexsha}")
-        refcheckdocs_logs = self.__make_refcheckdocs()
-        refcheckdocs_log_path.write_text(refcheckdocs_logs)
-        self.logger.debug(f"Saved refcheckdocs logs to {refcheckdocs_log_path}")
-        dt_binding_check_logs = self.__make_dt_binding_check()
-        dt_binding_check_log_path.write_text(dt_binding_check_logs)
-        self.logger.debug(f"Saved dt_binding_check logs to {dt_binding_check_log_path}")
+        if refcheckdocs_log_path.exists() and dt_binding_check_log_path.exists():
+            self.logger.debug(f"Using cached dt-checker logs for {commit.hexsha}")
+            return refcheckdocs_log_path, dt_binding_check_log_path
 
-        return refcheckdocs_log_path.read_text(), dt_binding_check_log_path.read_text()
+        super().make_config()
+
+        self.logger.debug(f"Running dt-checker on: {commit.hexsha}")
+        try:
+            refcheckdocs_logs = self.__make_refcheckdocs()
+            refcheckdocs_log_path.write_text(refcheckdocs_logs)
+            self.logger.debug(f"Saved refcheckdocs logs to {refcheckdocs_log_path}")
+        except KeyboardInterrupt:
+            refcheckdocs_log_path.unlink(missing_ok=True)
+            raise
+        try:
+            dt_binding_check_logs = self.__make_dt_binding_check()
+            dt_binding_check_log_path.write_text(dt_binding_check_logs)
+            self.logger.debug(
+                f"Saved dt_binding_check logs to {dt_binding_check_log_path}"
+            )
+        except KeyboardInterrupt:
+            dt_binding_check_log_path.unlink(missing_ok=True)
+            raise
+
+        return refcheckdocs_log_path, dt_binding_check_log_path
 
     def setup(self) -> None:
         self.logger.debug("Setting up dt-check")
@@ -111,12 +134,27 @@ class DtCheck(StaticAnalysis):
             return output
 
         self.logger.debug(f"Preparing kernel tree for dt checks")
-        # super().clean_tree()
-        super().make_config()  # TODO change back to _make_allmodconfig
-        refcheck, binding = self.__get_dt_checker_logs(self.commit)
+
+        parent_refcheck_path, parent_binding_path = None, None
+        if self.commit.parents:
+            super().reset_tree(self.commit.parents[0])
+            parent_refcheck_path, parent_binding_path = self.__get_dt_checker_logs(
+                self.commit.parents[0]
+            )
+
+        super().clean_tree()
+        super().reset_tree(self.commit)
+        refcheck_path, binding_path = self.__get_dt_checker_logs(self.commit)
+
+        if parent_refcheck_path and parent_binding_path:
+            refcheck = super().diff_new_records(parent_refcheck_path, refcheck_path)
+            binding = super().diff_new_records(parent_binding_path, binding_path)
+        else:
+            refcheck = refcheck_path.read_text()
+            binding = binding_path.read_text()
 
         if not refcheck and not binding:
-            self.logger.info("No dt-checker errors")
+            self.logger.info("No new dt-checker errors")
             return output
         if len(refcheck) > 0:
             output += f"refcheckdocs:\n{refcheck}\n"

--- a/patchwise/patch_review/static_analysis/dtbs_check.py
+++ b/patchwise/patch_review/static_analysis/dtbs_check.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+from pathlib import Path
+from typing import Optional
 
+from git.objects.commit import Commit
+
+from patchwise import SANDBOX_PATH
 from patchwise.patch_review.decorators import (
     register_long_review,
     register_static_analysis_review,
@@ -21,7 +26,20 @@ class DtbsCheck(StaticAnalysis):
 
     DEPENDENCIES = []
 
-    def __run_dtbs_check(self, sha: str) -> str:
+    def __run_dtbs_check(self, commit: Optional[Commit] = None) -> Path:
+        """Retrieves and caches dtbs_check log for a given kernel tree and SHA."""
+        logs_dir = Path(SANDBOX_PATH) / "dt-checker-logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        if not commit:
+            commit = self.commit
+
+        dtbs_check_log_path = logs_dir / f"{commit.hexsha}_dtbs_check.log"
+
+        if dtbs_check_log_path.exists():
+            self.logger.debug(f"Using cached dtbs_check log for {commit.hexsha}")
+            return dtbs_check_log_path
+
         kernel_dir = self.docker_manager.sandbox_path / "kernel"
         cfg_opts = [
             "CONFIG_ARM64_ERRATUM_843419=n",
@@ -33,24 +51,32 @@ class DtbsCheck(StaticAnalysis):
         super().make_config(
             arch=arch, extra_args=cfg_opts
         )  # TODO use _make_allmodconfig
-        dtbs_check_output = super().run_cmd_with_timer(
-            cmd=[
-                "make",
-                "-C",
-                str(kernel_dir),
-                f"-j{os.cpu_count()}",
-                "-s",
-                f"O={self.docker_manager.build_dir}",
-                f"ARCH={arch}",
-                "LLVM=1",
-                "dtbs_check",
-            ]
-            + cfg_opts,
-            cwd=str(self.docker_manager.build_dir),
-            desc=f"dtbs_check",
-        )
-        # logfile.write_text(dtbs_check_output) # TODO log to file and check for cache
-        return dtbs_check_output
+
+        self.logger.debug(f"Running dtbs_check on: {commit.hexsha}")
+        try:
+            dtbs_check_output = super().run_cmd_with_timer(
+                cmd=[
+                    "make",
+                    "-C",
+                    str(kernel_dir),
+                    f"-j{os.cpu_count()}",
+                    "-s",
+                    f"O={self.docker_manager.build_dir}",
+                    f"ARCH={arch}",
+                    "LLVM=1",
+                    "dtbs_check",
+                ]
+                + cfg_opts,
+                cwd=str(self.docker_manager.build_dir),
+                desc=f"dtbs_check",
+            )
+            dtbs_check_log_path.write_text(dtbs_check_output)
+            self.logger.debug(f"Saved dtbs_check log to {dtbs_check_log_path}")
+        except KeyboardInterrupt:
+            dtbs_check_log_path.unlink(missing_ok=True)
+            raise
+
+        return dtbs_check_log_path
 
     def setup(self) -> None:
         pass
@@ -66,9 +92,22 @@ class DtbsCheck(StaticAnalysis):
         self.logger.debug(f"Modified DT files: {dt_files}")
 
         self.logger.debug(f"Running dtbs_check for commit: {self.commit.message}")
-        output = self.__run_dtbs_check(self.commit.hexsha)
+
+        parent_log = None
+        if self.commit.parents:
+            super().reset_tree(self.commit.parents[0])
+            parent_log = self.__run_dtbs_check(self.commit.parents[0])
+
+        super().clean_tree()
+        super().reset_tree(self.commit)
+        current_log = self.__run_dtbs_check(self.commit)
+
+        if parent_log:
+            output = super().diff_new_records(parent_log, current_log)
+        else:
+            output = current_log.read_text()
 
         if not output:
-            self.logger.info("No dtbs_check errors found")
+            self.logger.info("No new dtbs_check errors found")
 
         return output

--- a/patchwise/patch_review/static_analysis/static_analysis.py
+++ b/patchwise/patch_review/static_analysis/static_analysis.py
@@ -2,8 +2,32 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import re
+from pathlib import Path
+
+from git.objects.commit import Commit
 
 from patchwise.patch_review.patch_review import PatchReview
+
+
+# Matches the first line of a dt-schema record: a non-indented path ending in
+# .yaml/.dtb/.dtbo followed by ':' (format_error's separator). Rejects Python
+# tracebacks, make errors, and other stderr chatter which don't have this shape.
+#
+# Matches:
+#   /home/.../foo.yaml: title: 'X' should not be valid under ...
+#   /home/.../bar.dtb: pinctrl@13800 (...): reg: ... is too long
+#   arch/.../baz.dtb: /soc/.../x: failed to match any schema with compatible: [...]
+#   /path/to/file.yaml:42:7: title: ...                  (linecol form)
+#   overlay.dtbo: ...
+#
+# Rejects:
+#   '  File "/.../dtb_validate.py", line 89, in check_subtree'   (indented frame)
+#   'Traceback (most recent call last):'                         (no .yaml/.dtb/.dtbo:)
+#   'jsonschema.exceptions._WrappedReferencingError: ...'        (no .yaml/.dtb/.dtbo:)
+#   'make[2]: *** [Makefile:14: ...] Error 1'                    (no .yaml/.dtb/.dtbo:)
+#   "warning: python package 'yamllint' not installed, skipping" (no .yaml/.dtb/.dtbo:)
+_DT_RECORD_ANCHOR_RE = re.compile(r"^\S.*\.(?:yaml|dtb|dtbo):")
 
 
 class StaticAnalysis(PatchReview):
@@ -14,6 +38,58 @@ class StaticAnalysis(PatchReview):
     tools. Subclasses should override the `run` method.
     """
 
+    def reset_tree(self, commit: Commit) -> None:
+        """Reset the in-container kernel tree to the given commit."""
+        self.logger.debug(f"Reset tree to {commit.hexsha}")
+        kernel_dir = self.docker_manager.sandbox_path / "kernel"
+        proc = self.docker_manager.run_command(
+            ["git", "reset", "--hard", commit.hexsha],
+            cwd=str(kernel_dir),
+        )
+        proc.communicate()
+
+    def group_records(self, text: str) -> list[str]:
+        """
+        Group each anchor line (matching `_DT_RECORD_ANCHOR_RE`) with its
+        subsequent indented continuation lines into a single record. Blank
+        lines and any non-indented line that is not an anchor are dropped.
+        Single-line outputs (refcheckdocs) degenerate to one record per line.
+        """
+        records: list[str] = []
+        current: list[str] = []
+        for line in text.splitlines():
+            if not line:
+                if current:
+                    records.append("\n".join(current))
+                    current = []
+            elif line.startswith("\t"):
+                if current:
+                    current.append(line)
+            elif _DT_RECORD_ANCHOR_RE.match(line):
+                if current:
+                    records.append("\n".join(current))
+                current = [line]
+            else:
+                if current:
+                    records.append("\n".join(current))
+                    current = []
+        if current:
+            records.append("\n".join(current))
+        return records
+
+    def diff_new_records(self, baseline_path: Path, current_path: Path) -> str:
+        """
+        Return records present in `current_path` but not in `baseline_path`,
+        preserving current's order.
+        """
+        baseline = set(self.group_records(baseline_path.read_text()))
+        new = [
+            r
+            for r in self.group_records(current_path.read_text())
+            if r not in baseline
+        ]
+        return "\n".join(new)
+
     def clean_tree(self, arch: str = "arm"):
         self.logger.debug("Cleaning kernel tree")
         kernel_dir = self.docker_manager.sandbox_path / "kernel"
@@ -22,6 +98,7 @@ class StaticAnalysis(PatchReview):
                 "make",
                 "-C",
                 str(kernel_dir),
+                f"O={self.docker_manager.build_dir}",
                 f"-j{os.cpu_count()}",
                 "-s",
                 "ARCH=" + arch,


### PR DESCRIPTION
Run dt_binding_check / refcheckdocs / dtbs_check against both the parent
commit and the current commit, cache the per-commit log files, then
diff the two by record so only errors introduced by the commit under
review are reported.

Closes #79 