### PR TITLE
Allow grep file filter to target directories

### DIFF
--- a/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py
@@ -1268,6 +1268,7 @@ regulator-name.
             return {"ok": False, "error": f"invalid regex: {e}"}
 
         file_filter: Optional[str] = None
+        file_filter_is_dir = False
         if file:
             try:
                 self._abs_in_kernel(file)
@@ -1276,10 +1277,24 @@ regulator-name.
             file_filter = self._kernel_rel(file)
             container_path = str(self.docker_manager.kernel_dir / file_filter)
             check = self.docker_manager.run_command(
-                ["test", "-f", container_path], cwd=None
+                [
+                    "sh",
+                    "-c",
+                    (
+                        'if [ -f "$1" ]; then echo file; '
+                        'elif [ -d "$1" ]; then echo dir; '
+                        "else echo missing; fi"
+                    ),
+                    "sh",
+                    container_path,
+                ],
+                cwd=None,
             )
-            check.communicate()
-            if check.returncode != 0:
+            stdout, _ = check.communicate()
+            path_kind = stdout.strip()
+            if path_kind == "dir":
+                file_filter_is_dir = True
+            elif path_kind != "file":
                 return {"ok": False, "error": f"file not found: {file_filter}"}
 
         kernel_dir = self.docker_manager.kernel_dir
@@ -1292,13 +1307,14 @@ regulator-name.
             "--max-count",
             "500",
         ]
-        if file_filter:
+        if file_filter and not file_filter_is_dir:
             rg_cmd += ["-e", pattern, str(kernel_dir / file_filter)]
         else:
             globs = [g.strip() for g in glob.split(",")] if glob else ["*.c", "*.h"]
             for g in globs:
                 rg_cmd += ["--glob", g]
-            rg_cmd += ["-e", pattern, str(kernel_dir)]
+            search_root = kernel_dir / file_filter if file_filter else kernel_dir
+            rg_cmd += ["-e", pattern, str(search_root)]
 
         try:
             output = self.run_cmd_with_timer(

--- a/patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py
+++ b/patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py
@@ -96,14 +96,15 @@ TOOLS = [
                     },
                     "file": {
                         "type": "string",
-                        "description": "Optional kernel-relative file to restrict the search to.",
+                        "description": (
+                            "Optional kernel-relative file or directory to scope the search. "
+                            "Glob is ignored when this names a single file."
+                        ),
                     },
                     "glob": {
                         "type": "string",
                         "description": (
-                            "Comma-separated ripgrep glob patterns to filter which files "
-                            "are searched (e.g. '*.dts,*.dtsi,*.yaml' or 'Kconfig,Makefile'). "
-                            "Ignored when `file` is set. Defaults to '*.c,*.h'."
+                            "Comma-separated ripgrep glob patterns. Defaults to '*.c,*.h'."
                         ),
                     },
                 },

--- a/tests/ai_code_review/test_tools.py
+++ b/tests/ai_code_review/test_tools.py
@@ -278,6 +278,28 @@ def test_grep_glob_kconfig(review: AiCodeReview) -> None:
     ), "non-Kconfig file slipped through glob filter"
 
 
+def test_grep_directory_filter_honors_glob(review: AiCodeReview) -> None:
+    """file=<dir> searches inside that subtree and still applies glob filters."""
+    result = review.dispatch_tool(
+        "grep",
+        {
+            "pattern": "qcom,msm8226-adsp-pil",
+            "file": "Documentation/devicetree/bindings/remoteproc",
+            "glob": "*.yaml",
+        },
+    )
+    assert result.get("ok"), f"directory-scoped grep failed: {result}"
+    hits = result.get("result", [])
+    assert result.get("total", 0) >= 1, "expected YAML hits under remoteproc bindings"
+    assert all(
+        h["path"].startswith("Documentation/devicetree/bindings/remoteproc/")
+        for h in hits
+    ), "hit outside requested directory slipped through file filter"
+    assert all(
+        h["path"].endswith(".yaml") for h in hits
+    ), "non-YAML file slipped through glob filter"
+
+
 def test_grep_glob_star_no_hits(review: AiCodeReview) -> None:
     """glob=* with a garbage pattern returns ok with zero hits."""
     result = review.dispatch_tool(
@@ -316,12 +338,8 @@ def test_grep_glob_star_qcom_msm8226_adsp_pil(review: AiCodeReview) -> None:
             {"pattern": "anything", "file": "../../../etc/passwd"},
             "escapes kernel tree",
         ),
-        (
-            {"pattern": "anything", "file": "drivers/remoteproc"},
-            "file not found",
-        ),
     ],
-    ids=["invalid_regex", "missing_file", "path_escape", "file_is_directory"],
+    ids=["invalid_regex", "missing_file", "path_escape"],
 )
 def test_grep_errors(
     review: AiCodeReview, args: Dict[str, Any], expected_error: str


### PR DESCRIPTION
## Summary

- allow the `grep` tool's `file` argument to target either a regular file or a directory
- keep direct-file grep behavior unchanged, while applying `glob` filters for directory-scoped recursive searches
- update the tool schema text so models know `file=<dir>` is supported
- add coverage for `file=<directory>` combined with `glob=*.yaml`

Fixes #88.

## Testing

- `python3 -m py_compile patchwise/patch_review/ai_review/ai_code_review/ai_code_review.py patchwise/patch_review/ai_review/ai_code_review/tool_definitions.py tests/ai_code_review/test_tools.py`
- `git diff --check`

The full `tests/ai_code_review/test_tools.py` suite requires the Docker-backed linux-next fixture, so I kept local verification to syntax and whitespace checks.
