### PR TITLE
Accelerate reviews of non .c/.h files

### DIFF
--- a/patchwise/patch_review/static_analysis/coccicheck.py
+++ b/patchwise/patch_review/static_analysis/coccicheck.py
@@ -80,14 +80,17 @@ class Coccicheck(StaticAnalysis):
         os.symlink(target, self.symlink_path)
 
     def run(self) -> str:
-        # TODO make sure that setup() runs in order for run() to run
+        modified_files = set(self.commit.stats.files.keys())
+        if not any(f.endswith((".c", ".h")) for f in modified_files):
+            self.logger.info("No .c/.h files changed, skipping coccicheck")
+            return ""
+
         self.logger.debug(f"Running cocci_check")
 
         # First, prepare the kernel build system
         self._prepare_kernel_build()
 
         output = ""
-        modified_files = set(self.commit.stats.files.keys())
         line_re = re.compile(r"^([^:]+):\d+:\d+-\d+:.*")
 
         directories: set[str] = set()

--- a/patchwise/patch_review/static_analysis/sparse.py
+++ b/patchwise/patch_review/static_analysis/sparse.py
@@ -30,6 +30,11 @@ class Sparse(StaticAnalysis):
         kernel_dir = self.docker_manager.sandbox_path / "kernel"
         build_dir = self.docker_manager.build_dir
 
+        modified_files = set(self.commit.stats.files.keys())
+        if not any(f.endswith((".c", ".h")) for f in modified_files):
+            logger.info("No .c/.h files changed, skipping sparse")
+            return ""
+
         logger.info("=== SPARSE DEBUG: Starting sparse analysis ===")
         logger.info(f"Docker kernel dir: {kernel_dir}")
         logger.info(f"Docker build dir: {build_dir}")


### PR DESCRIPTION
Sparse, coccicheck, and AiCodeReview only produce output for .c/.h files present in the patch. Skip those reviews early when the commit contains no .c/.h changes, avoiding expensive kernel builds that would produce empty results anyway.