### PR TITLE
dtbs: ensure output ends with a newline

### DIFF
--- a/patchwise/patch_review/static_analysis/dtbs_check.py
+++ b/patchwise/patch_review/static_analysis/dtbs_check.py
@@ -109,5 +109,7 @@ class DtbsCheck(StaticAnalysis):
 
         if not output:
             self.logger.info("No new dtbs_check errors found")
-
+        elif not output.endswith("\n"):
+            output += "\n"
+            
         return output


### PR DESCRIPTION
dtbs_check output did not always end with a trailing newline when
errors were present. 

This caused formatting issues where subsequent tool output would be
appended on the same line as the dtbs_check result.

Fix this by ensuring a trailing newline is added before returning
the output when missing.