### PR TITLE
Add false-positive RAG support for AiCodeReview

### DIFF
--- a/patchwise/default_config.yaml
+++ b/patchwise/default_config.yaml
@@ -13,12 +13,14 @@ git_committer:
     name: "Patchwise"
     email: "patchwise@qualcomm.com"
 ai:
+    # The `openai/` prefix is the LiteLLM provider hint; keep it in the value.
     model: "openai/Pro"
     provider: "https://api.openai.com/v1"
     # API key for the AI model API. Leave empty to fall back to the provider's
     # usual environment variable (e.g. OPENAI_API_KEY). Override in
     # ~/.config/patchwise_config.yaml.
     api_key: ""
+    max_tokens: 32000
     # Maps LiteLLM model strings to human-friendly display names shown in
     # mail replies (see get_model_name()). Override in
     # ~/.config/patchwise_config.yaml, e.g.:
@@ -26,6 +28,19 @@ ai:
     #     models:
     #       openai/Pro: "GPT-5"
     models: {}
+    fp_tools:
+        embedding_model: "huggingface/sentence-transformers/all-MiniLM-L6-v2"
+        embedding_provider: "https://api-inference.huggingface.co/v1"
+        verify_max_tokens: 32000
+        # ChromaDB path for confirmed false positives.
+        # Defaults to the sandbox path (SANDBOX_PATH/fp_vector_db).
+        # Override with an absolute path to persist across runs.
+        vector_db_path: ""
+        similarity_threshold: 0.65
+        # Higher threshold = stricter match required = fewer but more relevant
+        # false positive hits returned. Lower = more hits, less precise.
+        default_top_k: 3
+
 api_key_disclaimer:
     message: "PatchWise uses LiteLLM to interact with your preferred model provider (default: OpenAI). LiteLLM will automatically retrieve the API key from your environment variables if it is set based on the API URL provided to LiteLLM (default: OpenAI). Please confirm that you acknowledge that your API key may be used, if set in your environment. Select 'Yes' to proceed, 'No' to abort, and 'Yes. Don't show again' to proceed and disable this prompt."
     options: ["Yes", "No", "Yes. Don't show again"]

--- a/patchwise/mail_handler/handler.py
+++ b/patchwise/mail_handler/handler.py
@@ -18,6 +18,7 @@ from patchwise import SANDBOX_PATH
 from patchwise.logger_setup import LOG_PATH
 from patchwise.mail_handler.ai_models import get_model_name
 from patchwise.mail_handler.config import DeprecatedList, MailConfig
+from patchwise.mail_handler.patch_issue_collector import PatchIssueCollector, is_approval_reply, _message_date
 from patchwise.mail_handler.utils import (
     decode_header_value,
     domain_in,
@@ -29,6 +30,9 @@ from patchwise.patch_review import (
     fix_reported_issues,
     review_commit,
     PatchReviewResults,
+)
+from patchwise.patch_review.ai_review.fp_tools.unfixed_issue_collector import (
+    UnfixedIssueCollector,
 )
 from patchwise.patch_review.decorators import (
     LLM_REVIEWS,
@@ -81,7 +85,6 @@ def find_deprecated_list(
     return None
 
 
-# List of checks to determine if we should completely ignore the message
 def should_ignore(msg: EmailMessage, config: MailConfig) -> bool:
     if not domain_in(msg["From"], config.accepted_sender_domains):
         logger.info(f"Sender domain not accepted: {msg['From']}")
@@ -97,10 +100,6 @@ def should_ignore(msg: EmailMessage, config: MailConfig) -> bool:
 
     if subject_is_empty(msg):
         logger.info(f"Empty subject: {msg['Message-Id']}")
-        return True
-
-    if subject_is_reply(msg.get("Subject")):
-        logger.info(f"Subject is a reply: {msg['Message-Id']}")
         return True
 
     if msg.get("From"):
@@ -276,7 +275,7 @@ def get_patch_series(
         else:
             patches.append(sibling)
 
-    patches.sort(key=lambda m: utils.parsedate_to_datetime(m["Date"]))
+    patches.sort(key=_message_date)
 
     base_commit: Optional[str] = None
     if cover:
@@ -356,6 +355,27 @@ def decode_single_header(contents):
     return None
 
 
+def _process_approval_for_patch_issues(
+    approval_msg: EmailMessage,
+    evidence_collector: "PatchIssueCollector",
+    unfixed_collector,
+) -> None:
+    """Extract FP evidence from *approval_msg* and hand off to the FP pipeline.
+
+    mail_handler responsibility ends here — extract PatchReviewHistory and
+    pass to UnfixedIssueCollector which owns dedup, LLM call, and DB storage.
+    """
+    patch_review_history_list = evidence_collector.collect_patch_review_history(approval_msg)
+    for patch_review_history in patch_review_history_list:
+        logger.info(
+            "FP: '%s'  versions=%d  diff_lines=%d — passing to FP pipeline",
+            patch_review_history.patch_title,
+            len(patch_review_history.ai_issues),
+            patch_review_history.final_diff.count("\n"),
+        )
+        unfixed_collector.extract_and_store(patch_review_history)
+
+
 def process_mail(
     criteria,
     reviews: set[str],
@@ -366,7 +386,9 @@ def process_mail(
     logger.info(f"IMAP: {config.imap.server}:{config.imap.port}")
     logger.info(f"SMTP: {config.smtp.server}:{config.smtp.port}")
 
+    unfixed_collector = UnfixedIssueCollector()
     mail_client = MailClient(config, send=send)
+    evidence_collector = PatchIssueCollector(mail_client)
 
     search_ids = mail_client.search(criteria)
 
@@ -375,8 +397,14 @@ def process_mail(
         message_id = decode_single_header(msg["Message-Id"])
         logger.info(f"Handling {message_id} ({msg['Subject']})")
 
-        # Check if we can handle the message
         if should_ignore(msg, config):
+            mail_client.mark_as_processed(search_id)
+            continue
+
+        # Reply emails are skipped, but approval trailers trigger FP collection first.
+        if subject_is_reply(msg.get("Subject")):
+            if is_approval_reply(msg):
+                _process_approval_for_patch_issues(msg, evidence_collector, unfixed_collector)
             mail_client.mark_as_processed(search_id)
             continue
 

--- a/patchwise/mail_handler/mail_client.py
+++ b/patchwise/mail_handler/mail_client.py
@@ -282,6 +282,38 @@ class MailClient:
         exceptions=(imaplib.IMAP4.error, imaplib.IMAP4.abort, OSError, ConnectionError),
         on_retry=_imap_noop_or_reconnect,
     )
+    def fetch_message_by_id(self, message_id: str) -> Optional[EmailMessage]:
+        """Fetch a single message by its exact ``Message-Id`` header value."""
+        search_ids = self._imap.search(["HEADER", "Message-Id", message_id])
+        if not search_ids:
+            return None
+        return self.fetch_message(search_ids[0])
+
+    @retry(
+        max_retries=_MAX_IMAP_RETRIES,
+        exceptions=(imaplib.IMAP4.error, imaplib.IMAP4.abort, OSError, ConnectionError),
+        on_retry=_imap_noop_or_reconnect,
+    )
+    def search_by_subject(self, *fragments: str) -> List[EmailMessage]:
+        """Return all messages whose subject contains every fragment (AND).
+
+        Each positional argument becomes a separate IMAP ``SUBJECT`` criterion;
+        IMAP implicitly ANDs multiple criteria.
+        """
+        criteria: List = []
+        for fragment in fragments:
+            criteria.extend(["SUBJECT", fragment])
+        search_ids = self._imap.search(criteria)
+        messages = []
+        for search_id in search_ids:
+            messages.append(self.fetch_message(search_id))
+        return messages
+
+    @retry(
+        max_retries=_MAX_IMAP_RETRIES,
+        exceptions=(imaplib.IMAP4.error, imaplib.IMAP4.abort, OSError, ConnectionError),
+        on_retry=_imap_noop_or_reconnect,
+    )
     def mark_as_processed(self, search_id) -> None:
         if self._send:
             self._imap.add_flags([search_id], [FLAGGED])

--- a/patchwise/mail_handler/patch_issue_collector.py
+++ b/patchwise/mail_handler/patch_issue_collector.py
@@ -1,0 +1,250 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from datetime import datetime, timezone
+from email import utils as email_utils
+import logging
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from typing import List, Optional
+
+from patchwise.mail_handler.utils import decode_header_value, subject_is_reply
+
+logger = logging.getLogger(__name__)
+
+_APPROVAL_RE = re.compile(
+    r"(?mi)"
+    r"(?:Reviewed-by"
+    r"|LGTM"
+    r")"
+    r"|^[ \t]*(?:Applied|Accepted)\.?[ \t]*$"
+)
+_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]*\]\s*)+", re.IGNORECASE)
+_COVER_INDEX_RE = re.compile(r"\[[^\]]*\b0/\d+\b[^\]]*\]", re.IGNORECASE)
+_VERSION_RE = re.compile(r"\[[^\]]*\bv(\d+)\b[^\]]*\]", re.IGNORECASE)
+_AI_ISSUE_SECTION_HEADER_RE = re.compile(r"\*\*Code Review\*\*\s*:", re.IGNORECASE)
+
+
+@dataclass
+class PatchVersionIssueReport:
+    """Patchwise AI code review for one version of a patch."""
+    exact_subject: str
+    version: str
+    ai_review: str
+    message_id: str = ""
+
+
+@dataclass
+class PatchReviewHistory:
+    """All evidence collected from an approved patch series.
+
+    Contains the unified diff of the final accepted version and the
+    Patchwise AI code reviews from every prior version v1..vf.
+    """
+    patch_title: str
+    final_diff: str
+    ai_issues: List[PatchVersionIssueReport] = field(default_factory=list)
+
+
+def is_approval_reply(msg: EmailMessage) -> bool:
+    """Return True if *msg* body contains a recognisable approval trailer."""
+    body = _remove_quoted_lines(_extract_email_body(msg))
+    return bool(_APPROVAL_RE.search(body))
+
+
+def _extract_email_body(msg: EmailMessage) -> str:
+    if msg.is_multipart():
+        plain_part = msg.get_body(preferencelist=("plain",))
+        if plain_part is not None:
+            try:
+                return plain_part.get_content()
+            except (LookupError, UnicodeDecodeError):
+                payload = plain_part.get_payload(decode=True)
+                if isinstance(payload, bytes):
+                    return payload.decode("utf-8", errors="replace")
+
+    payload = msg.get_payload(decode=True)
+    if isinstance(payload, bytes):
+        return payload.decode(msg.get_content_charset() or "utf-8", errors="replace")
+
+    try:
+        return msg.get_content()
+    except (KeyError, LookupError, UnicodeDecodeError):
+        return str(msg.get_payload() or "")
+
+
+def _remove_quoted_lines(body: str) -> str:
+    return "\n".join(
+        line for line in body.splitlines() if not line.lstrip().startswith(">")
+    )
+
+
+def _bare_subject(subject: str) -> str:
+    """Strip all bracket-tag prefixes and return the bare patch title."""
+    return _PREFIX_RE.sub("", decode_header_value(subject)).strip()
+
+
+def _version_label(subject: str) -> str:
+    """Return version label ('v1', 'v2', …) from a subject, defaulting to 'v1'."""
+    match = _VERSION_RE.search(subject)
+    return f"v{match.group(1)}" if match else "v1"
+
+
+def _version_number(version: str) -> int:
+    """Return numeric version from a version label like 'v3' → 3."""
+    match = re.search(r"(\d+)", version)
+    return int(match.group(1)) if match else 1
+
+
+def _is_cover_letter(subject: str) -> bool:
+    return bool(_COVER_INDEX_RE.search(decode_header_value(subject)))
+
+
+def _extract_ai_issue_section(body: str) -> Optional[str]:
+    """Return everything written below **Code Review**: in *body*, or None."""
+    match = _AI_ISSUE_SECTION_HEADER_RE.search(body)
+    if not match:
+        return None
+    text = body[match.end():].strip()
+    return text or None
+
+
+def _message_date(msg: EmailMessage) -> datetime:
+    try:
+        parsed = email_utils.parsedate_to_datetime(msg["Date"])
+    except (TypeError, ValueError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _extract_patch_diff(raw_email: bytes) -> Optional[str]:
+    """Extract only the unified diff from a raw patch email via git mailinfo."""
+    with tempfile.TemporaryDirectory() as tmp:
+        msg_path = tmp + "/msg"
+        patch_path = tmp + "/patch"
+        try:
+            subprocess.run(
+                ["git", "mailinfo", msg_path, patch_path],
+                input=raw_email,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f"git mailinfo failed: {e.stderr.decode(errors='replace')}")
+            return None
+        with open(patch_path, "rb") as f:
+            patch = f.read().decode("utf-8", errors="replace")
+    return patch or None
+
+
+class PatchIssueCollector:
+    """Extract false-positive evidence from approval reply emails."""
+
+    def __init__(self, mail_client) -> None:
+        self._mail = mail_client
+
+    def collect_patch_review_history(
+        self, approval_msg: EmailMessage
+    ) -> List[PatchReviewHistory]:
+        """Return one PatchReviewHistory per patch touched by *approval_msg*."""
+        in_reply_to = (approval_msg.get("In-Reply-To") or "").strip()
+        if not in_reply_to:
+            logger.warning("Approval mail has no In-Reply-To; skipping.")
+            return []
+
+        final_patch = self._mail.fetch_message_by_id(in_reply_to)
+        if final_patch is None:
+            logger.warning("Could not fetch In-Reply-To=%s", in_reply_to)
+            return []
+
+        final_patch_subject = decode_header_value(final_patch.get("Subject", ""))
+
+        if _is_cover_letter(final_patch_subject):
+            logger.debug("FP Case 2 — cover-letter approval: %s", final_patch_subject)
+            siblings = self._mail.fetch_patch_series(in_reply_to)
+            patches = [
+                msg
+                for msg in siblings
+                if not _is_cover_letter(decode_header_value(msg.get("Subject", "")))
+                and not subject_is_reply(decode_header_value(msg.get("Subject", "")))
+            ]
+            patches.sort(key=_message_date)
+        else:
+            logger.debug("FP Case 1 — single-patch approval: %s", final_patch_subject)
+            patches = [final_patch]
+
+        patch_review_history_list: List[PatchReviewHistory] = []
+        for patch_msg in patches:
+            patch_review_history = self._collect_single_patch_review_history(patch_msg)
+            if patch_review_history is not None:
+                patch_review_history_list.append(patch_review_history)
+        return patch_review_history_list
+
+    def _collect_single_patch_review_history(
+        self, patch_msg: EmailMessage
+    ) -> Optional[PatchReviewHistory]:
+        """Build PatchReviewHistory for a single approved patch message."""
+        final_diff = _extract_patch_diff(patch_msg.as_bytes())
+        if final_diff is None:
+            subject = decode_header_value(patch_msg.get("Subject", ""))
+            logger.warning("No diff extracted from: %s", subject)
+            return None
+
+        final_subject = decode_header_value(patch_msg.get("Subject", ""))
+        patch_title = _bare_subject(final_subject)
+        version_reviews = find_ai_patch_issue_reports(final_subject, self._mail)
+
+        return PatchReviewHistory(
+            patch_title=patch_title,
+            final_diff=final_diff,
+            ai_issues=version_reviews,
+        )
+
+
+def find_ai_patch_issue_reports(
+    final_subject: str,
+    mail_client,
+) -> List[PatchVersionIssueReport]:
+    """Find Patchwise AI code reviews for all patch versions up to and including vf.
+
+    Searches the inbox by bare patch title and, for each version found, immediately
+    fetches its AI review mail and extracts the **Code Review**: section.  Returns
+    versions sorted oldest-first.
+    """
+    bare_title = _bare_subject(final_subject)
+    if not bare_title:
+        logger.warning("Could not derive bare title from: %s", final_subject)
+        return []
+
+    final_version_num = _version_number(_version_label(final_subject))
+
+    reviews: List[PatchVersionIssueReport] = []
+    for ai_msg in mail_client.search_by_subject("[Patchwise AI Review]", bare_title):
+        subject = decode_header_value(ai_msg.get("Subject", ""))
+        if not re.search(r"patchwise", ai_msg.get("From", ""), re.IGNORECASE):
+            continue
+        if _version_number(_version_label(subject)) > final_version_num:
+            continue
+
+        body = _extract_email_body(ai_msg)
+        section = _extract_ai_issue_section(body)
+        if section:
+            msg_id = decode_header_value(ai_msg.get("Message-ID", "")).strip()
+            version = _version_label(subject)
+            reviews.append(
+                PatchVersionIssueReport(
+                    exact_subject=subject,
+                    version=version,
+                    ai_review=section,
+                    message_id=msg_id,
+                )
+            )
+            logger.debug("Captured Code Review for %s (%s)", subject, version)
+
+    reviews.sort(key=lambda r: _version_number(r.version))
+    return reviews

--- a/patchwise/patch_review/ai_agent/agent.py
+++ b/patchwise/patch_review/ai_agent/agent.py
@@ -23,6 +23,7 @@ from patchwise.patch_review.ai_agent.tool_definitions import TOOLS
 from patchwise.ui import events
 from patchwise.utils.config import parse_config
 from patchwise.utils.decorators import retry
+from patchwise.patch_review.ai_review.fp_tools.false_positive_issue_db import get_fp_db
 
 urllib3.disable_warnings()
 
@@ -119,11 +120,23 @@ class Agent:
         self.current_label: str = ""
         self.current_iteration: int = 0
 
+        # FP database injected by the review pipeline before the filter phase.
+        self.fp_db = None                             # Optional[FalsePositiveDB]
+        self._fp_db_initialized: bool = False
+        self._seen_verdicts: set = set()                # key → "warned" | "accepted"
+
         self.seen_files |= self._files_in_diff()
 
         self.kernel_path = kernel_path
         self._docs_subdir = self._detect_docs_tree()
 
+    def initialize_fp_db(self):
+        if not self._fp_db_initialized:
+            self.fp_db = get_fp_db()
+            self._fp_db_initialized = True
+
+
+    @classmethod
     @retry(
         max_retries=10,
         exceptions=(
@@ -133,21 +146,20 @@ class Agent:
             litellm.OpenAIError,
         ),
     )
-    def completion_with_retry(self, **kwargs) -> Any:
-        kwargs.setdefault("model", Agent.model)
-        kwargs.setdefault("api_base", Agent.api_base)
-        kwargs.setdefault("api_key", Agent.api_key)
-        self.logger.debug(
-            f"Making API call with model: {self.model}, api_base: {Agent.api_base}"
-        )
-        response = litellm.completion(**kwargs)
+    def completion_with_retry(cls, **kwargs) -> Any:
+        kwargs.setdefault("model", cls.model)
+        kwargs.setdefault("api_base", cls.api_base)
+        kwargs.setdefault("api_key", cls.api_key)
+        return litellm.completion(**kwargs)
+
+    def _update_token_usage(self, response: Any) -> None:
+        """Extract token usage from a completion response and update instance counters."""
         usage = getattr(response, "usage", None)
         if usage is not None:
             self.tokens_used += getattr(usage, "total_tokens", 0) or 0
             pt = getattr(usage, "prompt_tokens", 0) or 0
             self.last_prompt_tokens = pt
             self.peak_prompt_tokens = max(self.peak_prompt_tokens, pt)
-        return response
 
     def budget_remaining(self) -> bool:
         """True while the current phase's token ceiling is unset or not yet hit."""
@@ -255,7 +267,11 @@ class Agent:
                 )
                 break
 
+            self.logger.debug(
+                f"Making API call with model: {self.model}, api_base: {Agent.api_base}"
+            )
             response = self.completion_with_retry(**completion_kwargs)
+            self._update_token_usage(response)
             msg = response.choices[0].message
             # Bedrock rejects toolUse.name outside [a-zA-Z0-9_-]; scrub here so a
             # hallucinated name with invalid chars cannot poison replayed history.
@@ -317,7 +333,11 @@ class Agent:
             }
         )
 
+        self.logger.debug(
+            f"Making API call with model: {self.model}, api_base: {Agent.api_base}"
+        )
         response = self.completion_with_retry(**completion_kwargs)
+        self._update_token_usage(response)
         content = response.choices[0].message.content or ""
         self._log_final_response(response, content)
         return content
@@ -1681,6 +1701,26 @@ class Agent:
             raise ValueError(f"verdicts path escapes sandbox: {path}")
         return path
 
+    def _check_fp_database(self, finding: str) -> list:
+        """Search the FP vector DB for findings similar to *finding*.
+
+        Returns a list of match dicts (keys: issue_description, code_snippet,
+        reason) sorted by similarity.  Empty list when no match exists or the
+        DB is unavailable. Uses the configured default top_k so the embedder has
+        enough context to surface relevant stored patterns.
+        """
+        if self.fp_db is None or not self.fp_db.is_available():
+            return []
+        return self.fp_db.search_similar_issues(code_snippet="", issue_text=finding)
+
+    def _write_verdict(self, finding: str, impact: str, verdict: str, reason: str, proof: str) -> None:
+        record = {"finding": finding, "impact": impact, "verdict": verdict, "reason": reason, "proof": proof}
+        path = self.verdicts_path_for(self.current_label or "unit")
+        with open(path, "a") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        events.emit(events.VERDICT, label=self.current_label, finding=finding,
+                impact=impact, verdict=verdict, reason=reason)
+
     def _tool_record_verdict(
         self,
         finding: str,
@@ -1694,21 +1734,45 @@ class Agent:
         the per-phase verdicts file, so verdicts are durable and read back
         reliably (no giant array to parse, no markdown to re-split).
         `impact` is its severity; `verdict` is keep/drop; `proof` substantiates a
-        drop. The keep/drop policy is applied by the review."""
-        path = self.verdicts_path_for(self.current_label or "unit")
-        record = {
-            "finding": finding,
-            "impact": impact,
-            "verdict": verdict,
-            "reason": reason,
-            "proof": proof,
-        }
-        with open(path, "a") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
-        events.emit(events.VERDICT, label=self.current_label, finding=finding,
-                    impact=impact, verdict=verdict, reason=reason)
-        return {"ok": True, "recorded": verdict or "verdict"}
+        drop. The keep/drop policy is applied by the review.
 
+        When verdict is "keep", the FP database is queried for a semantically
+        similar stored false positive. If one is found the tool returns ok=False
+        with a warning so the AI re-examines. A second call with the same
+        finding is accepted unconditionally (accepted_on_try=True) to prevent
+        infinite loops. The JSONL line is always written first so the verdict
+        is durable regardless of the warning path.
+        """
+        if verdict.strip().lower() == "keep":
+            matches = self._check_fp_database(finding)
+            if not matches or finding in self._seen_verdicts:
+                self._write_verdict(finding, impact, verdict, reason, proof)
+                return {"ok": True, "recorded": verdict, "accepted_on_try": True}
+            else:
+                self._seen_verdicts.add(finding)
+                self._write_verdict(finding, impact, verdict, reason, proof)
+                match_lines = [
+                    f"  issue_description: {m.get('issue_description', '')}\n"
+                    f"  code_snippet:      {m.get('code_snippet', '') or '(none)'}\n"
+                    f"  reason:            {m.get('reason', '')}"
+                    for m in matches
+                ]
+                return {
+                    "ok": False,
+                    "recorded": verdict,
+                    "warning": (
+                        f"{len(matches)} semantically similar finding(s) were previously "
+                        "confirmed as false positives:\n\n"
+                        + "\n\n".join(match_lines)
+                        + "\n\nFinding was recorded as keep for safety. "
+                        "If this is actually a false positive, call record_verdict "
+                        "again with verdict='drop' and proof."
+                    ),
+                }
+
+        # drop (or any non-keep verdict): write directly without FP check
+        self._write_verdict(finding, impact, verdict, reason, proof)
+        return {"ok": True, "recorded": verdict}
     def dispatch_tool(self, name: str, args: dict) -> dict:
         """Dispatch an agent tool by name. Returns {ok, ...}."""
         read_tools = {
@@ -1773,4 +1837,3 @@ class Agent:
             f"{prefix}/{f}" if prefix else f
             for f in stdout.strip().splitlines()
         }
-

--- a/patchwise/patch_review/ai_review/ai_code_review.py
+++ b/patchwise/patch_review/ai_review/ai_code_review.py
@@ -587,6 +587,7 @@ finding with record_verdict as you work through them.
         response = self.agent.completion_with_retry(
             messages=messages, stream=False
         )
+        self.agent._update_token_usage(response)
         raw2 = response.choices[0].message.content or ""
         return self._extract_json(raw2)
 
@@ -962,6 +963,20 @@ finding with record_verdict as you work through them.
                 out.append(obj)
         return out
 
+    @staticmethod
+    def _latest_verdicts_by_finding(
+        entries: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        latest: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+        without_finding: List[Dict[str, Any]] = []
+        for entry in entries:
+            finding = str(entry.get("finding") or "").strip()
+            if not finding:
+                without_finding.append(entry)
+                continue
+            latest[finding] = entry
+        return without_finding + list(latest.values())
+
     def _fp_filter_phase(
         self, findings: List[Tuple[Dict[str, Any], str]]
     ) -> Tuple[str, int]:
@@ -988,6 +1003,7 @@ finding with record_verdict as you work through them.
             {"role": "user", "content": fp_user},
         ]
         self.agent.current_label = "fp-filter"
+        self.agent.initialize_fp_db()
         # Reset the verdicts file so a re-run in the same sandbox starts clean.
         verdicts_path = self.agent.verdicts_path_for("fp-filter")
         verdicts_path.unlink(missing_ok=True)
@@ -1007,6 +1023,7 @@ finding with record_verdict as you work through them.
             if not isinstance(parsed, list):
                 parsed = self._finalize_json(fp_messages, raw, "verdict array")
             entries = [v for v in parsed if isinstance(v, dict)] if isinstance(parsed, list) else []
+        entries = self._latest_verdicts_by_finding(entries)
         if not entries:
             # No verdicts at all: keep everything rather than risk dropping a real
             # defect. The cleanup pass still renders the raw findings.
@@ -1060,6 +1077,7 @@ finding with record_verdict as you work through them.
             "stream": False,
         }
         response = self.agent.completion_with_retry(**completion_kwargs)
+        self.agent._update_token_usage(response)
         review = response.choices[0].message.content or ""
         if review.strip() == "No issues found.":
             return ""

--- a/patchwise/patch_review/ai_review/fp_tools/config.py
+++ b/patchwise/patch_review/ai_review/fp_tools/config.py
@@ -1,0 +1,87 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from patchwise import SANDBOX_PATH
+from patchwise.utils.config import parse_config
+
+
+@dataclass
+class FpToolsConfig:
+    model: str | None
+    provider: str | None
+    embedding_model: str | None
+    embedding_provider: str | None
+    verify_max_tokens: int
+    vector_db_path: Path
+    similarity_threshold: float
+    default_top_k: int
+
+    @classmethod
+    def load(cls) -> "FpToolsConfig":
+        cfg = parse_config()
+        ai = cfg.get("ai", {})
+        fp = ai.get("fp_tools") or {}
+        provider = fp.get("provider") or ai.get("provider")
+
+        raw_path = fp.get("vector_db_path")
+        vector_db_path = (
+            Path(str(raw_path)).expanduser()
+            if raw_path and str(raw_path).strip()
+            else SANDBOX_PATH / "fp_vector_db"
+        )
+
+        return cls(
+            model=fp.get("model") or ai.get("model"),
+            provider=provider,
+            embedding_model=fp.get("embedding_model"),
+            embedding_provider=fp.get("embedding_provider") or provider,
+            verify_max_tokens=int(fp.get("verify_max_tokens") or 32000),
+            vector_db_path=vector_db_path,
+            similarity_threshold=float(fp.get("similarity_threshold") or 0.65),
+            default_top_k=int(fp.get("default_top_k") or 3),
+        )
+
+
+_cfg = FpToolsConfig.load()
+
+DEFAULT_LLM_MODEL                  = _cfg.model
+DEFAULT_LLM_API_BASE               = _cfg.provider
+DEFAULT_EMBEDDING_MODEL            = _cfg.embedding_model
+DEFAULT_EMBEDDING_API_BASE         = _cfg.embedding_provider
+DEFAULT_VERIFY_MAX_TOKENS          = _cfg.verify_max_tokens
+DEFAULT_FP_DB_PATH                 = _cfg.vector_db_path
+DEFAULT_FP_DB_SIMILARITY_THRESHOLD = _cfg.similarity_threshold
+DEFAULT_FP_DB_TOP_K                = _cfg.default_top_k
+
+
+def configure_litellm_client() -> None:
+    import litellm
+    litellm.ssl_verify = False
+
+
+def require_model(model: str | None, *, config_key: str, option: str) -> str:
+    if model and model.strip():
+        return model.strip()
+    raise ValueError(f"Model is required. Set {config_key} or pass {option}.")
+
+
+def litellm_kwargs(
+    *,
+    model: str | None,
+    api_base: str | None,
+    model_config_key: str,
+    model_option: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    request = {
+        "model": require_model(model, config_key=model_config_key, option=model_option),
+        **kwargs,
+    }
+    if api_base:
+        request["api_base"] = api_base
+    return request

--- a/patchwise/patch_review/ai_review/fp_tools/false_positive_issue_db.py
+++ b/patchwise/patch_review/ai_review/fp_tools/false_positive_issue_db.py
@@ -1,0 +1,302 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import hashlib
+import litellm
+import logging
+from pathlib import Path
+
+from patchwise.patch_review.ai_review.fp_tools.config import (
+    DEFAULT_EMBEDDING_API_BASE,
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_FP_DB_PATH,
+    DEFAULT_FP_DB_SIMILARITY_THRESHOLD,
+    DEFAULT_FP_DB_TOP_K,
+    configure_litellm_client,
+    litellm_kwargs,
+)
+from patchwise.utils.decorators import retry
+
+
+logger = logging.getLogger(__name__)
+
+VECTOR_DB_PATH = DEFAULT_FP_DB_PATH
+_FP_DB_COLLECTION = "patchwise_false_positives"
+_FP_DB_SIMILARITY_THRESHOLD = DEFAULT_FP_DB_SIMILARITY_THRESHOLD
+_FP_DB_DEFAULT_TOP_K = DEFAULT_FP_DB_TOP_K
+
+
+class IssueEmbeddingClient:
+    """LiteLLM embedding wrapper used by FalsePositiveDB."""
+
+    def __init__(self, model: str | None, api_base: str | None) -> None:
+        self._model = model
+        self._api_base = api_base
+
+    @retry(
+        max_retries=10,
+        exceptions=(
+            litellm.Timeout,
+            litellm.RateLimitError,
+            litellm.InternalServerError,
+        ),
+    )
+    def embed(self, text: str) -> list[float] | None:
+        try:
+            configure_litellm_client()
+            litellm.drop_params = True
+            response = litellm.embedding(
+                **litellm_kwargs(
+                    model=self._model,
+                    api_base=self._api_base,
+                    model_config_key="ai.fp_tools.embedding_model",
+                    model_option="--embedding-model",
+                    input=[text],
+                )
+            )
+            return response.data[0]["embedding"]
+        except Exception as exc:
+            logger.error("FalsePositiveDB: embedding failed: %s", exc)
+            return None
+
+
+class FalsePositiveDB:
+    """Persistent vector database for confirmed false-positive findings."""
+
+    def __init__(
+        self,
+        db_path: Path | None = None,
+        embedding_model: str | None = None,
+        embedding_api_base: str | None = None,
+        top_k: int = _FP_DB_DEFAULT_TOP_K,
+        threshold: float = _FP_DB_SIMILARITY_THRESHOLD,
+    ) -> None:
+        self._db_path = Path(db_path or VECTOR_DB_PATH).expanduser()
+        self._embedding_model = embedding_model or DEFAULT_EMBEDDING_MODEL
+        self._embedding_api_base = embedding_api_base or DEFAULT_EMBEDDING_API_BASE
+        self._top_k = top_k
+        self._threshold = threshold
+        self._client = None
+        self._collection = None
+        self._ready = False
+        self._embedder = IssueEmbeddingClient(
+            model=self._embedding_model,
+            api_base=self._embedding_api_base,
+        )
+
+    def initialize(self) -> None:
+        try:
+            import chromadb as _chromadb
+        except ImportError:
+            logger.warning("chromadb not installed; FalsePositiveDB unavailable")
+            return
+
+        if not self._embedding_model:
+            logger.warning(
+                "ai.fp_tools.embedding_model not set; FalsePositiveDB unavailable"
+            )
+            return
+
+        self._db_path.mkdir(parents=True, exist_ok=True)
+        try:
+            self._client = _chromadb.PersistentClient(path=str(self._db_path))
+        except Exception as exc:
+            logger.error("Failed to initialize ChromaDB at %s: %s", self._db_path, exc)
+            return
+
+        self._collection = self._client.get_or_create_collection(
+            name=_FP_DB_COLLECTION,
+            metadata={"hnsw:space": "cosine"},
+        )
+        self._ready = True
+        logger.debug(
+            "FalsePositiveDB ready — model=%r db=%s entries=%d",
+            self._embedding_model,
+            self._db_path,
+            self._collection.count(),
+        )
+
+    def is_available(self) -> bool:
+        return self._ready and self._collection is not None
+
+    def add_false_positive_issue(
+        self,
+        patch_title: str,
+        code_snippet: str,
+        issue_description: str,
+        reason: str,
+        issue_label: str = "",
+        message_id: str = "",
+    ) -> bool:
+        if not self.is_available():
+            logger.warning("FalsePositiveDB not initialized; skipping add_false_positive_issue")
+            return False
+
+        issue_description = (issue_description or "").strip()
+        if not issue_description:
+            raise ValueError("issue_description must not be empty")
+
+        patch_title = (patch_title or "").strip()
+        code_snippet = (code_snippet or "").strip()
+        reason = (reason or "").strip()
+        issue_label = (issue_label or patch_title).strip()
+        if not issue_label:
+            raise ValueError("issue_label or patch_title must not be empty")
+
+        doc_text = _format_issue_embedding_document(issue_description, code_snippet)
+        doc_id = _make_issue_record_id(issue_label)
+        embedding = self._embedder.embed(doc_text)
+        if embedding is None:
+            return False
+
+        self._collection.upsert(
+            ids=[doc_id],
+            embeddings=[embedding],
+            documents=[doc_text],
+            metadatas=[
+                {
+                    "record_id": doc_id,
+                    "patch_title": patch_title,
+                    "issue_label": issue_label,
+                    "code_snippet": code_snippet,
+                    "issue_description": issue_description,
+                    "reason": reason,
+                    "message_id": message_id,
+                }
+            ],
+        )
+        logger.debug("FalsePositiveDB: stored %s", doc_id)
+        return True
+
+    def has_patch_issue_records(self, patch_title: str) -> bool:
+        if not self.is_available():
+            return False
+        patch_title = (patch_title or "").strip()
+        if not patch_title:
+            return False
+        result = self._collection.get(
+            where={"patch_title": {"$eq": patch_title}},
+            limit=1,
+            include=[],
+        )
+        return len(result.get("ids", [])) > 0
+
+    def has_review_message_id(self, message_id: str) -> bool:
+        if not self.is_available():
+            return False
+        message_id = (message_id or "").strip()
+        if not message_id:
+            return False
+        result = self._collection.get(
+            where={"message_id": {"$eq": message_id}},
+            limit=1,
+            include=[],
+        )
+        return len(result.get("ids", [])) > 0
+
+    def search_similar_issues(
+        self,
+        code_snippet: str,
+        issue_text: str,
+        top_k: int | None = None,
+        threshold: float | None = None,
+    ) -> list[dict]:
+        if not self.is_available():
+            return []
+
+        issue_text = (issue_text or "").strip()
+        if not issue_text:
+            return []
+
+        count = self._collection.count()
+        if count == 0:
+            return []
+
+        top_k = top_k if top_k is not None else self._top_k
+        threshold = threshold if threshold is not None else self._threshold
+        if top_k <= 0:
+            return []
+
+        query_text = _format_issue_embedding_document(issue_text, (code_snippet or "").strip())
+        embedding = self._embedder.embed(query_text)
+        if embedding is None:
+            return []
+
+        n_results = min(max(top_k, 1), count)
+        results = self._collection.query(
+            query_embeddings=[embedding],
+            n_results=n_results,
+            include=["metadatas", "distances"],
+        )
+
+        output = []
+        metadatas = results.get("metadatas") or [[]]
+        distances = results.get("distances") or [[]]
+        for issue_meta, distance in zip(metadatas[0], distances[0]):
+            similarity = 1 - distance
+            if similarity < threshold:
+                continue
+            output.append(
+                {
+                    "patch_title": issue_meta.get("patch_title", ""),
+                    "issue_label": issue_meta.get("issue_label", ""),
+                    "code_snippet": issue_meta.get("code_snippet", ""),
+                    "issue_description": issue_meta.get("issue_description", ""),
+                    "reason": issue_meta.get("reason", ""),
+                    "record_id": issue_meta.get("record_id", ""),
+                    "distance": round(distance, 4),
+                }
+            )
+
+        return sorted(output, key=lambda item: item["distance"])[:top_k]
+
+    def get_count(self) -> int:
+        if not self.is_available():
+            return 0
+        return self._collection.count()
+
+    def clear(self) -> None:
+        if not self.is_available():
+            return
+        try:
+            self._client.delete_collection(_FP_DB_COLLECTION)
+        except ValueError:
+            pass
+        self._collection = self._client.get_or_create_collection(
+            name=_FP_DB_COLLECTION,
+            metadata={"hnsw:space": "cosine"},
+        )
+        logger.debug("FalsePositiveDB: collection cleared")
+
+
+def _format_issue_embedding_document(issue_description: str, code_snippet: str) -> str:
+    if code_snippet:
+        return f"Issue: {issue_description}\n\nCode:\n{code_snippet}"
+    return issue_description
+
+
+def _make_issue_record_id(issue_label: str) -> str:
+    hash_hex = hashlib.sha256(issue_label.encode()).hexdigest()[:16]
+    return f"fp_{hash_hex}"
+
+
+_FP_DB_INSTANCE: FalsePositiveDB | None = None
+
+
+def get_fp_db() -> FalsePositiveDB:
+    global _FP_DB_INSTANCE
+    if _FP_DB_INSTANCE is None:
+        _FP_DB_INSTANCE = FalsePositiveDB()
+        _FP_DB_INSTANCE.initialize()
+    return _FP_DB_INSTANCE
+
+
+def main() -> None:
+    from patchwise.patch_review.ai_review.fp_tools.false_positive_issue_db_cli import main as cli_main
+    cli_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/patchwise/patch_review/ai_review/fp_tools/false_positive_issue_db_cli.py
+++ b/patchwise/patch_review/ai_review/fp_tools/false_positive_issue_db_cli.py
@@ -1,0 +1,151 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from patchwise.patch_review.ai_review.fp_tools.false_positive_issue_db import (
+    FalsePositiveDB,
+    VECTOR_DB_PATH,
+    _FP_DB_DEFAULT_TOP_K,
+    _FP_DB_SIMILARITY_THRESHOLD,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _initialize_false_positive_db(path: Path) -> FalsePositiveDB | None:
+    db = FalsePositiveDB(db_path=path)
+    db.initialize()
+    if not db.is_available():
+        logger.error("FalsePositiveDB not available — check ai.fp_tools config.")
+        return None
+    return db
+
+
+def _load_false_positive_issue_records(path: Path) -> list[dict]:
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    if text.startswith("["):
+        records = json.loads(text)
+        if not isinstance(records, list):
+            raise ValueError("JSON input must be an array of objects")
+        return records
+    records = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            logger.warning("Skipping line %d: %s", lineno, exc)
+    return records
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    parser = argparse.ArgumentParser(
+        description="Manage the FalsePositiveDB — populate, search, clear, count.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    pop = sub.add_parser("populate", help="Append FP records from a JSON/JSONL file into the DB.")
+    pop.add_argument("input", type=Path, help="JSON array or JSONL file with FP records.")
+    pop.add_argument("--db", type=Path, default=VECTOR_DB_PATH)
+
+    srch = sub.add_parser("search", help="Search FalsePositiveDB semantically.")
+    srch.add_argument("--issue", required=True, help="Issue description to search for.")
+    srch.add_argument("--code", default="", help="Code snippet (optional).")
+    srch.add_argument("--db", type=Path, default=VECTOR_DB_PATH)
+    srch.add_argument("--n", type=int, default=_FP_DB_DEFAULT_TOP_K)
+    srch.add_argument("--threshold", type=float, default=_FP_DB_SIMILARITY_THRESHOLD)
+
+    clr = sub.add_parser("clear", help="Delete all entries from FalsePositiveDB.")
+    clr.add_argument("--db", type=Path, default=VECTOR_DB_PATH)
+
+    cnt = sub.add_parser("count", help="Print number of stored findings.")
+    cnt.add_argument("--db", type=Path, default=VECTOR_DB_PATH)
+
+    args = parser.parse_args(argv)
+    if not args.cmd:
+        parser.print_help()
+        return
+
+    if args.cmd == "populate":
+        if not args.input.exists():
+            logger.error("Input file not found: %s", args.input)
+            return
+        try:
+            records = _load_false_positive_issue_records(args.input)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            logger.error("Failed to load %s: %s", args.input, exc)
+            return
+        if not records:
+            logger.error("No records found in %s", args.input)
+            return
+        db = _initialize_false_positive_db(args.db)
+        if db is None:
+            return
+        stored = skipped = 0
+        for r in records:
+            try:
+                if db.add_false_positive_issue(
+                    patch_title=r["patch_title"],
+                    code_snippet=r.get("code_snippet", ""),
+                    issue_description=r["issue_description"],
+                    reason=r["reason"],
+                    issue_label=r.get("issue_label", ""),
+                    message_id=r.get("message_id", ""),
+                ):
+                    stored += 1
+            except ValueError as exc:
+                logger.warning("Skipping %r: %s", r.get("patch_title", "?"), exc)
+                skipped += 1
+        logger.info("Populate complete: %d added, %d skipped. DB total: %d",
+                    stored, skipped, db.get_count())
+
+    elif args.cmd == "search":
+        if args.n <= 0:
+            logger.error("--n must be greater than 0")
+            return
+        db = _initialize_false_positive_db(args.db)
+        if db is None:
+            return
+        results = db.search_similar_issues(
+            code_snippet=args.code, issue_text=args.issue,
+            top_k=args.n, threshold=args.threshold,
+        )
+        if not results:
+            print("No matches found above threshold.")
+            return
+        for i, r in enumerate(results, 1):
+            print(f"\nMatch {i} (distance={r['distance']}):")
+            print(f"  patch_title       : {r['patch_title']}")
+            print(f"  issue_label       : {r['issue_label']}")
+            print(f"  issue_description : {r['issue_description']}")
+            print(f"  code_snippet      : {r['code_snippet'] or '(none)'}")
+            print(f"  reason            : {r['reason']}")
+
+    elif args.cmd == "clear":
+        db = _initialize_false_positive_db(args.db)
+        if db is None:
+            return
+        db.clear()
+        logger.info("FalsePositiveDB cleared.")
+
+    elif args.cmd == "count":
+        db = _initialize_false_positive_db(args.db)
+        if db is None:
+            return
+        print(f"FalsePositiveDB entries: {db.get_count()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/patchwise/patch_review/ai_review/fp_tools/unfixed_issue_collector.py
+++ b/patchwise/patch_review/ai_review/fp_tools/unfixed_issue_collector.py
@@ -1,0 +1,296 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from litellm.exceptions import APIError as LitellmAPIError
+
+from patchwise.patch_review.ai_review.fp_tools.config import (
+    DEFAULT_LLM_API_BASE,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_VERIFY_MAX_TOKENS,
+    configure_litellm_client,
+)
+from patchwise.patch_review.ai_agent.agent import Agent
+from patchwise.patch_review.ai_review.ai_code_review import AiCodeReview
+from patchwise.patch_review.ai_review.fp_tools.false_positive_issue_db import get_fp_db
+
+logger = logging.getLogger(__name__)
+
+
+class LlmApiError(RuntimeError):
+    pass
+
+
+MODEL = DEFAULT_LLM_MODEL
+API_BASE = DEFAULT_LLM_API_BASE
+MAX_TOKENS = DEFAULT_VERIFY_MAX_TOKENS
+
+_SYSTEM_PROMPT = """\
+You are an expert Linux kernel engineer reviewing patch history.
+
+Your task:
+  - You will be given Patchwise AI code reviews from every version of a patch
+    series (v1 through vf) and the unified diff of the FINAL accepted version.
+  - Read ALL the code review sections across every version.
+  - For each distinct issue raised in ANY version, decide whether the FINAL
+    diff FULLY resolves it.
+  - Return ONLY the issues that are NOT fixed in the final diff.
+  - A single patch version may have multiple unfixed issues — emit one entry
+    per issue, each with the same patch_title but distinct issue_description.
+
+Output format — strict JSON array only, no markdown fences, no prose:
+
+[
+  {
+    "patch_title":       "<exact subject line of the patch version where this issue was found>",
+    "code_snippet":      "<only the directly affected lines — no context, no diff headers>",
+    "issue_description": "<one or two sentences — the specific defect only>",
+    "reason_not_fixed":  "<one sentence — what is still wrong in the final diff>"
+  }
+]
+
+If ALL issues are fixed, return an empty array: []
+
+Rules:
+- Output ONLY a valid JSON array — no extra text, no markdown.
+- Include an entry only when the final diff does NOT fully address the issue.
+- Partial fixes count as not fixed.
+- "patch_title" must be the exact subject line printed in the reviews.
+- One JSON object per issue — if a version has 3 unfixed issues, emit 3 objects
+  all with the same patch_title but each with a distinct issue_description.
+- "code_snippet": affected lines only. Empty string if not applicable.
+- "issue_description": plain technical terms, max two sentences.
+- "reason_not_fixed": one sentence citing the exact location still problematic.
+"""
+
+_USER_PROMPT = """\
+═══════════════════════════════════════════════════════════════════════
+CODE REVIEWS (all versions)
+═══════════════════════════════════════════════════════════════════════
+
+{all_reviews}
+
+═══════════════════════════════════════════════════════════════════════
+FINAL PATCH DIFF
+═══════════════════════════════════════════════════════════════════════
+
+{final_diff}
+"""
+
+
+@dataclass
+class UnfixedIssue:
+    patch_title: str
+    issue_label: str
+    code_snippet: str
+    issue_description: str
+    reason_not_fixed: str
+    message_id: str = ""
+
+
+class UnfixedIssueCollector:
+    """Collect and store unfixed review issues for one patch."""
+
+    def __init__(
+        self,
+        model: Optional[str] = MODEL,
+        api_base: Optional[str] = API_BASE,
+    ) -> None:
+        self._model = model
+        self._api_base = api_base
+
+    def extract_and_store(self, patch_issues) -> None:
+        db = get_fp_db()
+        if not db.is_available():
+            logger.warning("FalsePositiveDB unavailable — skipping '%s'", patch_issues.patch_title)
+            return
+
+        unfixed_issues = self.unfixed_issue_collector(patch_issues, db=db)
+        if not unfixed_issues:
+            logger.debug("All issues fixed in vf for '%s'", patch_issues.patch_title)
+            return
+
+        stored = 0
+        for issue in unfixed_issues:
+            try:
+                if db.add_false_positive_issue(
+                    patch_title=issue.patch_title,
+                    code_snippet=issue.code_snippet,
+                    issue_description=issue.issue_description,
+                    reason=issue.reason_not_fixed,
+                    issue_label=issue.issue_label,
+                    message_id=issue.message_id,
+                ):
+                    stored += 1
+            except ValueError as exc:
+                logger.warning("Skipping '%s': %s", issue.issue_label, exc)
+        logger.info("Stored %d unfixed issue(s) for '%s'", stored, patch_issues.patch_title)
+
+    def unfixed_issue_collector(self, patch_issues, db=None) -> List[UnfixedIssue]:
+        if not patch_issues.ai_issues:
+            return []
+
+        new_reviews = (
+            [review for review in patch_issues.ai_issues if not db.has_review_message_id(review.message_id)]
+            if db is not None
+            else list(patch_issues.ai_issues)
+        )
+        if not new_reviews:
+            logger.debug("All versions already indexed for '%s'", patch_issues.patch_title)
+            return []
+
+        msg_id_by_subject = {r.exact_subject: r.message_id for r in new_reviews}
+
+        try:
+            raw_issue_dicts = self._identify_unfixed_issues(new_reviews, patch_issues.final_diff)
+        except (LlmApiError, json.JSONDecodeError, ValueError) as exc:
+            logger.error("LLM error for '%s': %s", patch_issues.patch_title, exc)
+            return []
+
+        unfixed_issues = [
+            UnfixedIssue(
+                patch_title=str(raw_issue.get("patch_title", "")),
+                issue_label=str(raw_issue.get("patch_title", "")),
+                code_snippet=str(raw_issue.get("code_snippet", "")),
+                issue_description=str(raw_issue.get("issue_description", "")),
+                reason_not_fixed=str(raw_issue.get("reason_not_fixed", "")),
+                message_id=msg_id_by_subject.get(str(raw_issue.get("patch_title", "")), ""),
+            )
+            for raw_issue in raw_issue_dicts
+            if isinstance(raw_issue, dict) and raw_issue.get("issue_description", "").strip()
+        ]
+
+        counts = Counter(issue.patch_title for issue in unfixed_issues)
+        seen: Counter = Counter()
+        for issue in unfixed_issues:
+            if counts[issue.patch_title] > 1:
+                seen[issue.patch_title] += 1
+                issue.issue_label = f"{issue.patch_title}_({seen[issue.patch_title]})"
+
+        logger.debug("%d unfixed issue(s) for '%s'", len(unfixed_issues), patch_issues.patch_title)
+        return unfixed_issues
+
+    def _identify_unfixed_issues(self, version_reviews, final_diff: str) -> list:
+        all_reviews = "\n\n".join(
+            f"--- {review.exact_subject} ---\n\n{review.ai_review.strip()}"
+            for review in version_reviews
+        )
+        messages = [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _USER_PROMPT.format(
+                    all_reviews=all_reviews,
+                    final_diff=final_diff,
+                ),
+            },
+        ]
+        return self._request_unfixed_issue_analysis(messages)
+
+    def _request_unfixed_issue_analysis(self, messages: list) -> list:
+        try:
+            configure_litellm_client()
+            logger.debug(
+                f"Making API call with model: {self._model}, api_base: {self._api_base}"
+            )
+            response = Agent.completion_with_retry(
+                model=self._model,
+                api_base=self._api_base,
+                messages=messages,
+                stream=False,
+                max_tokens=MAX_TOKENS,
+            )
+        except LitellmAPIError as exc:
+            raise LlmApiError(str(exc)) from exc
+
+        llm_response_text = response.choices[0].message.content or ""
+        result = AiCodeReview._extract_json(llm_response_text)
+        if result is None:
+            raise ValueError("Could not parse LLM response as JSON")
+        if not isinstance(result, list):
+            raise ValueError(f"Expected JSON array, got {type(result).__name__}")
+        return result
+
+
+class _PatchReviewHistoryProxy:
+    class _PatchVersionIssueReport:
+        def __init__(self, d: dict) -> None:
+            self.exact_subject: str = d.get("exact_subject", "")
+            self.ai_review: str = d.get("ai_review", "")
+            self.message_id: str = d.get("message_id", "")
+
+    def __init__(self, d: dict) -> None:
+        self.patch_title: str = d.get("patch_title", "")
+        self.final_diff: str = d.get("final_diff", "")
+        self.ai_issues = [self._PatchVersionIssueReport(vr) for vr in d.get("ai_issues", [])]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collect unfixed issues from a PatchReviewHistory JSON and emit JSONL.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        required=True,
+        help="PatchReviewHistory JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="JSONL output (default: stdout).",
+    )
+    parser.add_argument("--model", default=MODEL)
+    parser.add_argument("--api-base", default=API_BASE, dest="api_base")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    if not args.input.exists():
+        logger.error("Input file not found: %s", args.input)
+        sys.exit(1)
+
+    try:
+        input_json = json.loads(args.input.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to parse input JSON: %s", exc)
+        sys.exit(1)
+
+    unfixed_issues = UnfixedIssueCollector(model=args.model, api_base=args.api_base).unfixed_issue_collector(
+        _PatchReviewHistoryProxy(input_json)
+    )
+    if not unfixed_issues:
+        logger.debug("All issues fixed — nothing to emit.")
+        return
+
+    output_file = open(args.output, "w", encoding="utf-8") if args.output else sys.stdout
+    try:
+        for issue in unfixed_issues:
+            output_file.write(json.dumps(asdict(issue), ensure_ascii=False) + "\n")
+    finally:
+        if args.output:
+            output_file.close()
+            logger.info("Results → %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/patchwise/patch_review/ai_review/root_cause_analysis.py
+++ b/patchwise/patch_review/ai_review/root_cause_analysis.py
@@ -599,7 +599,11 @@ record it with `record_finding`.
                 ),
             }
         ]
+        self.logger.debug(
+                f"Making API call with model: {self.model}, api_base: {Agent.api_base}"
+            )
         response = self.agent.completion_with_retry(messages=repair_messages, stream=False)
+        self.agent._update_token_usage(response)
         raw2 = response.choices[0].message.content or ""
         return self._extract_json(raw2)
 


### PR DESCRIPTION
This feature enables PatchWise to learn from human-approved patch review
threads and apply that knowledge to future AI code reviews. Currently,
AI-generated false positives can be reported repeatedly across later
reviews because PatchWise does not persist feedback implied by human
approvals.

With this change, when a patch is approved in mail mode, PatchWise
detects the approval reply, collects earlier PatchWise AI review findings
for that patch, compares them against the final accepted patch version,
and stores findings that remained unfixed as false-positive evidence.

During the `AiCodeReview` filter phase, PatchWise searches the persistent
false-positive database for semantically similar findings. When a similar
known false positive is found, the model is warned once and asked to re-
evaluate the finding before the final review is produced. This reduces
repeated false positives while keeping review findings safe by default.